### PR TITLE
Drop explicit dependency on CDB_File.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 	  <provide>perl(EDG::WP4::CCM::SyncFile)</provide>
 	</provides>
 	<requires>
-	  <require>perl(CDB_File)</require>
 	  <require>perl-JSON-XS &gt;= 2.3.0</require>
 	</requires>
 	<defaultDirmode>755</defaultDirmode>


### PR DESCRIPTION
It's actually optional, and as explained by Nathan, it makes it harder
to maintain SL4-based systems.
