### PR TITLE
Depend explicitly on Crypt::SSLeay.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
 	</provides>
 	<requires>
 	  <require>perl-JSON-XS &gt;= 2.3.0</require>
+	  <require>perl(Crypt::SSLeay)</require>
 	</requires>
 	<defaultDirmode>755</defaultDirmode>
 	<mappings>


### PR DESCRIPTION
Most sites will use HTTPS for transferring their profiles, and it's very 
suprising when Yum doesn't install it.
