### PR TITLE
Add quattor-fetch command symlink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,10 @@
                   <include>ccm-*</include>
                 </includes>
               </source>
+              <softlinkSource>
+                <destination>quattor-fetch</destination>
+                <location>ccm-fetch</location>
+              </softlinkSource>
             </sources>
             <configuration>false</configuration>
             <documentation>false</documentation>


### PR DESCRIPTION
Based on TCD's quattor_commands.tpl to begin the implementation of
https://trac.lal.in2p3.fr/Quattor/wiki/Development/Scrum/CommandRenaming

Includes a commit to replace the tabs in pom.xml with spaces.
