### PR TITLE
Defined noquattor constants in CCM::Fetch module

### DIFF
--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -14,6 +14,7 @@ BEGIN {
 use CAF::Application;
 use CAF::Reporter;
 use LC::Exception qw(SUCCESS throw_error);
+use EDG::WP4::CCM::Fetch qw(NOQUATTOR_FORCE);
 use strict;
 use warnings;
 our @ISA = qw(CAF::Application CAF::Reporter);
@@ -75,7 +76,7 @@ sub app_options {
           { NAME    => 'dbformat=s',
             HELP    => 'Format to use for storing profile' },
 
-          { NAME    => 'force-quattor',
+          { NAME    => NOQUATTOR_FORCE,
             DEFAULT => 0,
             HELP    => 'Fetch even if CCM updates are globally disabled' },
 
@@ -151,7 +152,7 @@ package main;
 use English;
 use LC::Exception qw(SUCCESS throw_error);
 use File::Basename;
-use EDG::WP4::CCM::Fetch qw(NOQUATTOR NOQUATTOR_EXITCODE);
+use EDG::WP4::CCM::Fetch qw(NOQUATTOR NOQUATTOR_EXITCODE NOQUATTOR_FORCE);
 use EDG::WP4::CCM::CacheManager;
 use LC::Exception;
 
@@ -198,7 +199,7 @@ if (defined $this_app->option("dbformat")) {
 }
 
 # Disable all updates if the flag is present
-if (-f NOQUATTOR && ! $this_app->option("force-quattor")) {
+if (-f NOQUATTOR && ! $this_app->option(NOQUATTOR_FORCE)) {
     $this_app->warn("CCM updates disabled globally (", NOQUATTOR, " present)");
     my $fh = CAF::FileEditor->new(NOQUATTOR);
     $this_app->warn("$fh") if $fh;

--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -69,7 +69,7 @@ BEGIN {
 
 use constant NOQUATTOR => "/etc/noquattor";
 use constant NOQUATTOR_EXITCODE => 3;
-
+use constant NOQUATTOR_FORCE => "force-quattor";
 
 use constant MAXPROFILECOUNTER => 9999 ;
 use constant ERROR => -1 ;


### PR DESCRIPTION
Allows other tools to use exitcode and filename.
