### PR TITLE
CCfg _readConfigFile should not retest if configuration file exists

### DIFF
--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -104,10 +104,6 @@ sub _readConfigFile ($)
 {
     my ($fn) = @_;
 
-    if (! -f $fn) {
-        throw_error("non-existing config file $fn");
-        return;        
-    }
     my $fh = CAF::FileReader->new($fn);
         
     foreach my $line (split ("\n", "$fh")) {
@@ -160,7 +156,7 @@ sub initCfg
 
         # Accept the configuration be read from pipes (i.e, stdin)
         unless (-f $cp || -p $cp) {
-            throw_error("configuration file not found");
+            throw_error("configuration file $cp not found");
             return ();
         }
     } else {

--- a/src/test/perl/test-ccfg.t
+++ b/src/test/perl/test-ccfg.t
@@ -50,7 +50,7 @@ my $fn = "$ccfgtmp/notexists";
 my $fh = CAF::FileReader->new($fn);
 ok(!-f $fn, "notexists file $fn doesn't exist");
 
-eok($ec, EDG::WP4::CCM::CCfg::_readConfigFile($fn), "_readConfigFile of not existing file");
+eok($ec, EDG::WP4::CCM::CCfg::initCfg($fn), "initCfg of not existing file");
 
 $fn = "$ccfgtmp/ccm_invalidkey.cfg";
 ok(-f $fn, "ccm_invalidkey file $fn does exist");


### PR DESCRIPTION
it is already tested in initCfg
partially fixes #46
