### PR TITLE
Support json_typed via config file

### DIFF
--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -50,29 +50,33 @@ my $DEF_EDG_LOC = "/usr";
 
 # Holds the default and all possible keys
 Readonly::Hash my %DEFAULT_CFG => {
+    "base_url"         => undef,
+    "ca_dir"           => undef,
+    "ca_file"          => undef,
+    "cache_root"       => "/var/lib/ccm",
+    "cert_file"        => undef,
+    "context"          => undef,
+    "dbformat"         => "GDBM_File",
     "debug"            => undef,
     "force"            => undef,
-    "profile"          => undef,
-    "profile_failover" => undef,
-    "context"          => undef,
-    "preprocessor"     => undef,
-    "cache_root"       => "/var/lib/ccm",
     "get_timeout"      => 30,
+    "keep_old"         => 2,
+    "key_file"         => undef,
     "lock_retries"     => 3,
     "lock_wait"        => 30,
+    "preprocessor"     => undef,
+    "profile"          => undef,
+    "profile_failover" => undef,
+    "purge_time"       => 86400,
     "retrieve_retries" => 3,
     "retrieve_wait"    => 30,
-    "cert_file"        => undef,
-    "key_file"         => undef,
-    "ca_file"          => undef,
-    "ca_dir"           => undef,
-    "base_url"         => undef,
-    "world_readable"   => undef,
-    "dbformat"         => "GDBM_File",
-    "keep_old"         => 2,
-    "purge_time"       => 86400,
     "trust"            => undef,
+    "world_readable"   => undef,
 };
+
+Readonly::Array our @CFG_KEYS => sort(keys(%DEFAULT_CFG));
+
+push(@EXPORT_OK, qw(@CFG_KEYS));
 
 # copy hash to hash ref
 my $cfg = {%DEFAULT_CFG};

--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -60,6 +60,7 @@ Readonly::Hash my %DEFAULT_CFG => {
     "debug"            => undef,
     "force"            => undef,
     "get_timeout"      => 30,
+    "json_typed"       => 0,
     "keep_old"         => 2,
     "key_file"         => undef,
     "lock_retries"     => 3,

--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -478,7 +478,13 @@ sub choose_interpreter
     my $tree;
     if ($self->{PROFILE_URL} =~ m{json(?:\.gz)?$}) {
         $tree = decode_json($profile);
-        return ('EDG::WP4::CCM::JSONProfileSimple', ['profile', $tree]);
+        my $module;
+        if ($self->{JSON_TYPED}) {
+            $module = 'EDG::WP4::CCM::JSONProfileTyped';
+        } else {
+            $module = 'EDG::WP4::CCM::JSONProfileSimple';
+        }
+        return ($module, ['profile', $tree]);
     }
 
     my $xmlParser = new XML::Parser(Style => 'Tree');

--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -33,7 +33,7 @@ use strict;
 use warnings;
 
 use Getopt::Long;
-use EDG::WP4::CCM::CCfg qw(getCfgValue);
+use EDG::WP4::CCM::CCfg qw(getCfgValue @CFG_KEYS);
 use EDG::WP4::CCM::DB;
 use CAF::Lock qw(FORCE_IF_STALE);
 use CAF::FileEditor;
@@ -152,13 +152,10 @@ sub _config($)
         return ();
     }
 
-    foreach my $p (
-        qw(debug get_timeout cert_file ca_file ca_dir force base_url
-        profile_failover context_url cache_root cert_file key_file
-        ca_file ca_dir lock_retries lock_wait retrieve_retries
-        retrieve_wait preprocessor world_readable tmp_dir dbformat)
-        )
-    {
+    my @keys = qw(tmp_dir context_url);
+    push(@keys, @CFG_KEYS);
+    foreach my $p (@keys) {
+        # do not override any predefined uppercase attributes
         $self->{uc($p)} ||= $param->{uc($p)} || getCfgValue($p);
     }
 

--- a/src/main/perl/JSONProfileTyped.pm
+++ b/src/main/perl/JSONProfileTyped.pm
@@ -26,21 +26,21 @@ This module has only C<interpret_node> method for the outside world.
 
 =head2 Type information from JSON::XS
 
-JSON profiles don't contain any explicit type information (as opposed to the 
+JSON profiles don't contain any explicit type information (as opposed to the
 XMLPAN output), e.g. JSON only supports 'number' where XMLPAN has 'long' and 'double'.
 
-It is up to the JSON decoder to provide us with this additional distinction. 
-The JSON package C<JSON::XS> does not expose the scalar type information. 
+It is up to the JSON decoder to provide us with this additional distinction.
+The JSON package C<JSON::XS> does not expose the scalar type information.
 
-However, we try to come up with correct proper type by relying on the property that 
-C<JSON::XS> supports C<json_string eq encode(copy(decode(json_string)))> 
-(implying that the instance returned by C<decode> has the C<XS> types 
+However, we try to come up with correct proper type by relying on the property that
+C<JSON::XS> supports C<json_string eq encode(copy(decode(json_string)))>
+(implying that the instance returned by C<decode> has the C<XS> types
 (and e.g. no stringification has happened)). However, this is best effort only.
 
 Imperative in the whole typed processing is that values from the decoded JSON
-are not assigned to any variable before the type information is extraced via the 
+are not assigned to any variable before the type information is extraced via the
 C<B::svref_2object> method. The scalar types (except for boolean) are then mapped to
-the C<B> classes: C<IV> is 'long', C<PV> is 'double' and C<NV> is 'string'. 
+the C<B> classes: C<IV> is 'long', C<PV> is 'double' and C<NV> is 'string'.
 Anything else will be mapped to string (including the combined classes C<PVNV> and C<PVIV>).
 
 TODO: The validity of this assumption is tested in the C<BEGIN{}> (and unittests).
@@ -58,7 +58,7 @@ use Scalar::Util qw(blessed);
 
 $SIG{__DIE__} = \&confess;
 
-# Turns a JSON Object (an unordered associative array) into a Perl hash 
+# Turns a JSON Object (an unordered associative array) into a Perl hash
 # reference with all the types and metadata from the profile.
 sub interpret_nlist
 {
@@ -91,22 +91,22 @@ sub interpret_list
 }
 
 # Map the C<B::SV> class from C<B::svref_2object> to a scalar type
-# C<IV> is 'long', C<PV> is 'double' and C<NV> is 'string'. 
-# Anything else will be mapped to string (including the combined 
+# C<IV> is 'long', C<PV> is 'double' and C<NV> is 'string'.
+# Anything else will be mapped to string (including the combined
 # classes C<PVNV> and C<PVIV>).
 # This only works due to the XS C API used by JSON::XS and if you call
-# B::svref_2object directly on the value without assigning it to a 
-# variable first. This is no magic function that will 
+# B::svref_2object directly on the value without assigning it to a
+# variable first. This is no magic function that will
 # "just work" on anything you throw at it.
 sub get_scalar_type
 {
     my $b_obj = shift;
-    
+
     if (! blessed($b_obj)) {
         # what was passed?
         return 'string';
     };
-    
+
     if ($b_obj->isa('B::IV')) {
         return 'long';
     } elsif ($b_obj->isa('B::NV')) {
@@ -114,7 +114,7 @@ sub get_scalar_type
     } elsif ($b_obj->isa('B::PV')) {
         return 'string';
     }
-    
+
     # TODO: log all else?
     return 'string';
 
@@ -124,10 +124,10 @@ sub get_scalar_type
 
 =head2 C<interpret_node>
 
-C<b_obj> is returned by the C<B::svref_2object()> method on the C<doc> 
+C<b_obj> is returned by the C<B::svref_2object()> method on the C<doc>
 (ideally before C<doc> is assigned).
 
-The initial call from C<Fetch> doesn't pass the C<b_obj> value, but that is 
+The initial call from C<Fetch> doesn't pass the C<b_obj> value, but that is
 acceptable since we do not expect the whole JSON profile to be a single scalar value.
 
 =cut

--- a/src/test/perl/test-ccfg.t
+++ b/src/test/perl/test-ccfg.t
@@ -8,7 +8,7 @@ use warnings;
 use Test::More;
 use CCMTest qw (eok);
 use LC::Exception qw(SUCCESS);
-use EDG::WP4::CCM::CCfg qw ();
+use EDG::WP4::CCM::CCfg qw (@CFG_KEYS);
 use Cwd;
 use Net::Domain qw(hostname hostdomain);
 
@@ -100,5 +100,11 @@ while (my ($k, $v) = each %expected) {
     is(EDG::WP4::CCM::CCfg::getCfgValue($k), $v, "Get ccm.conf ccfg param $k");
 }
 
+# Hard test for possible values (sorted)
+is_deeply(\@CFG_KEYS, [qw(base_url ca_dir ca_file cache_root cert_file
+    context dbformat debug force get_timeout keep_old
+    key_file lock_retries lock_wait preprocessor profile profile_failover
+    purge_time retrieve_retries retrieve_wait trust world_readable
+    )], "CFG_KEYS exports all possible configuration keys");
 
 done_testing();

--- a/src/test/perl/test-ccfg.t
+++ b/src/test/perl/test-ccfg.t
@@ -102,7 +102,7 @@ while (my ($k, $v) = each %expected) {
 
 # Hard test for possible values (sorted)
 is_deeply(\@CFG_KEYS, [qw(base_url ca_dir ca_file cache_root cert_file
-    context dbformat debug force get_timeout keep_old
+    context dbformat debug force get_timeout json_typed keep_old
     key_file lock_retries lock_wait preprocessor profile profile_failover
     purge_time retrieve_retries retrieve_wait trust world_readable
     )], "CFG_KEYS exports all possible configuration keys");


### PR DESCRIPTION
Add support for a boolean `json_typed` (default false) to the config file to use the `JSONProfileTyped` module to extract typed data from JSON profiles (as opposed to the default `JSONProfileSimple` that treats long and double as strings). This allows for the evaluation of this module and the default might change after a testing period.