### PR TITLE
ccm-fetch: add json_typed as command line option to ccm-fetch

### DIFF
--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -116,6 +116,9 @@ sub app_options {
           { NAME   => 'purge_time=i',
             HELP   => 'Number of seconds before purging inactive profiles' },
 
+          { NAME   => 'json_typed',
+            HELP   => 'Extract typed data from JSON profiles' },
+
           { NAME    => 'debug|d=i',
             DEFAULT => '0',
             HELP    => 'Turn on dubugging messages' });


### PR DESCRIPTION
Without this, ccm-fetch won't parse the configfile (which leads to serious issues when you set json_typed to true).