### PR TITLE
CCM Fetch warn when dealing with "profiles from future" due to timesync issues

### DIFF
--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -269,8 +269,20 @@ sub retrieve
     $fh->close();
 
     my $modified = $rs->last_modified();
-    if (!(defined($modified) && utime($modified, $modified, $cache))) {
-        $self->warn("Unable to set mtime for $cache: $!");
+
+    if ($modified) {
+        my $now = time();
+        if ($time < $modified) {
+            $self->warn("Profile has last_modified timestamp ",
+                        $modified - $now,
+                        " seconds in future (timestamp $modified)");
+        }
+
+        if (! utime($modified, $modified, $cache)) {
+            $self->warn("Unable to set mtime for $cache: $!");
+        }
+    } else {
+        $self->warn("Unable to set mtime for $cache: last_modified is undefined");
     }
 
     $fh = CAF::FileReader->new($cache, log => $self);

--- a/src/test/perl/test-cachemanager.t
+++ b/src/test/perl/test-cachemanager.t
@@ -168,8 +168,4 @@ ok ($lcidf->read() == 4 && $ccidf->read() == 4,
 make_file("$cp/td.txt", "1\n");
 my $url = "file:///$cp/td.txt";
 
-my $file;
-ok ($file = $cm -> cacheFile ($url),
-   "cm->cacheFile ($url)");
-
 done_testing();


### PR DESCRIPTION
Includes removal of unused cacheFile method which also deals with `last_modified` timestamp
Fixes #39 