### PR TITLE
Fetch using json_typed requires untainted decode_json 

### DIFF
--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -55,7 +55,7 @@ use GSSAPI;
 use JSON::XS v2.3.0 qw(decode_json);
 use Carp qw(carp confess);
 use HTTP::Message;
-use Taint::Runtime qw(taint_start taint_stop);
+use Taint::Runtime qw(taint_start taint_stop taint_enabled);
 
 use constant DEFAULT_GET_TIMEOUT => 30;
 
@@ -493,9 +493,10 @@ sub choose_interpreter
         my $module;
         if ($self->{JSON_TYPED}) {
             $module = 'EDG::WP4::CCM::JSONProfileTyped';
-            taint_stop;
+            my $t_enabled = taint_enabled();
+            taint_stop();
             $tree = decode_json($profile);
-            taint_start;
+            taint_start() if $t_enabled;
         } else {
             $module = 'EDG::WP4::CCM::JSONProfileSimple';
             $tree = decode_json($profile);

--- a/src/test/perl/json_typed.t
+++ b/src/test/perl/json_typed.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 11;
+use Test::More;
 use EDG::WP4::CCM::XMLPanProfile;
 use EDG::WP4::CCM::JSONProfileTyped;
 use EDG::WP4::CCM::Fetch;
@@ -14,8 +14,12 @@ use XML::Parser;
 use EDG::WP4::CCM::Fetch qw(ComputeChecksum);
 use CCMTest qw(compile_profile);
 use B;
+use Taint::Runtime qw(taint_start taint_enabled taint_stop);
 
 use Readonly;
+
+taint_start();
+ok(taint_enabled(), "taint enabled for json_typed testing");
 
 =pod
 
@@ -108,7 +112,13 @@ my $reference_result = EDG::WP4::CCM::XMLPanProfile->interpret_node(@$t);
 
 $fh = CAF::FileReader->new("target/test/json/${simple}.json");
 note("Profile contents: $fh");
+# This is what Fetch choose_interpreter does
+taint_stop();
+ok(! taint_enabled(), "taint disabled for json_typed decode_json");
 $t = decode_json("$fh");
+taint_start();
+ok(taint_enabled(), "taint reenabled for json_typed testing");
+
 my $our_result = EDG::WP4::CCM::JSONProfileTyped->interpret_node(profile => $t);
 
 # Do not explain before creating result. It might do some auto-stringification

--- a/src/test/perl/json_typed.t
+++ b/src/test/perl/json_typed.t
@@ -6,9 +6,7 @@ use warnings;
 use Test::More;
 use EDG::WP4::CCM::XMLPanProfile;
 use EDG::WP4::CCM::JSONProfileTyped;
-use EDG::WP4::CCM::Fetch;
 use CAF::FileReader;
-use JSON::XS qw(decode_json);
 use Test::Deep;
 use XML::Parser;
 use EDG::WP4::CCM::Fetch qw(ComputeChecksum);
@@ -113,11 +111,7 @@ my $reference_result = EDG::WP4::CCM::XMLPanProfile->interpret_node(@$t);
 $fh = CAF::FileReader->new("target/test/json/${simple}.json");
 note("Profile contents: $fh");
 # This is what Fetch choose_interpreter does
-taint_stop();
-ok(! taint_enabled(), "taint disabled for json_typed decode_json");
-$t = decode_json("$fh");
-taint_start();
-ok(taint_enabled(), "taint reenabled for json_typed testing");
+$t = EDG::WP4::CCM::Fetch::_decode_json("$fh", 1);
 
 my $our_result = EDG::WP4::CCM::JSONProfileTyped->interpret_node(profile => $t);
 


### PR DESCRIPTION
If not, all scalars have magic tainted flag and are B::PVMG. 
This is mainly an issue for `aii-shellfe` which seems to run with different taint level then e.g. `ccm-fetch`.