### PR TITLE
improve CCM  API with more convience methods and a CCM::Options class

### DIFF
--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -60,7 +60,7 @@ sub app_options {
 
           { NAME    => 'cache_root=s',
             DEFAULT => '/var/lib/ccm',
-            HELP    => 'Path of executable to be used to preprocess a profile with a context' },
+            HELP    => 'Basepath for the configuration cache' },
 
           { NAME    => 'get_timeout=i',
             DEFAULT => '30',
@@ -121,7 +121,7 @@ sub app_options {
 
           { NAME    => 'debug|d=i',
             DEFAULT => '0',
-            HELP    => 'Turn on dubugging messages' });
+            HELP    => 'Turn on debugging messages' });
 
     return \@options;
 }

--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -45,42 +45,181 @@ file.
 # ------------------------------------------------------
 
 my $ec          = LC::Exception::Context->new->will_store_errors;
-my $CONFIG_FN   = "ccm.conf";
-my $DEF_EDG_LOC = "/usr";
+Readonly my $DEF_EDG_LOC => "/usr";
+Readonly our $CONFIG_FN   => "/etc/ccm.conf";
+
+# Ordered list of all options in config file
+# semi-AppConfig style (NAME=option.suffix)
+# Based 15.4 DEFAULT_CFG from CCfg.pm (keys and default values)
+# and order and help of ccm-fetch (not all ccm-fetch options are here)
+Readonly::Array our @CONFIG_OPTIONS => (
+    {
+        option => 'profile',
+        suffix => '|p=s',
+        HELP => 'URL of profile to fetch',
+    },
+
+    {
+        option => 'profile_failover',
+        suffix => '=s',
+        HELP => 'URL of profile to fetch when --profile is not available',
+    },
+
+    {
+        option => 'context',
+        suffix => '|c=s',
+        HELP    => 'URL of context to fetch',
+    },
+
+    {
+        option => 'preprocessor',
+        suffix => '=s',
+        HELP    => 'Path of executable to be used to preprocess a profile with a context',
+    },
+
+    {
+        option => 'cache_root',
+        suffix => '=s',
+        DEFAULT => '/var/lib/ccm',
+        HELP    => 'Basepath for the configuration cache',
+    },
+
+    {
+        option => 'get_timeout',
+        suffix => '=i',
+        DEFAULT => 30,
+        HELP    => 'Timeout in seconds for HTTP GET operation',
+    },
+
+    {
+        # TODO: ccm-fetch has default 1
+        option => 'world_readable',
+        suffix => '=i',
+        HELP    => 'World readable profile flag 1/0',
+    },
+
+    {
+        option => 'force',
+        suffix => '|f',
+        HELP    => 'Fetch regardless of modification times',
+    },
+
+    {
+        option => 'dbformat',
+        suffix => '=s',
+        DEFAULT => 'GDBM_File',
+        HELP    => 'Format to use for storing profile',
+    },
+
+    {
+        option => 'retrieve_retries',
+        suffix => '=i',
+        DEFAULT => 3,
+        HELP    => 'Number of times fetch will attempt to retrieve a profile',
+    },
+
+    {
+        option => 'lock_retries',
+        suffix => '=i',
+        DEFAULT => 3,
+        HELP    => 'Number of times fetch will attempt to get the fetch lock',
+    },
+
+    {
+        option => 'retrieve_wait',
+        suffix => '=i',
+        DEFAULT => 30,
+        HELP    => 'Number of seconds that fetch will wait between retrieve attempts',
+    },
+
+    {
+        option => 'lock_wait',
+        suffix => '=i',
+        DEFAULT => 30,
+        HELP    =>  'Number of seconds that fetch will wait between lock attempts',
+    },
+
+    {
+        option => 'key_file',
+        suffix => '=s',
+        HELP    => 'Absolute file name for key file to use with HTTPS.',
+    },
+
+    {
+        option => 'cert_file',
+        suffix => '=s',
+        HELP    => 'Absolute file name for certificate file to use with HTTPS.',
+    },
+
+    {
+        option => 'ca_file',
+        suffix => '=s',
+        HELP    => 'File containing a bundle of trusted CA certificates for use with HTTPS.',
+    },
+
+    {
+        option => 'ca_dir',
+        suffix => '=s',
+        HELP   => 'Directory containing trusted CA certificates for use with HTTPS',
+    },
+
+    {
+        option => 'trust',
+        suffix => '=s',
+        HELP   => 'Kerberos principal to trust if using encrypted profiles',
+    },
+
+    {
+        option => 'keep_old',
+        suffix => '=i',
+        DEFAULT => 2,
+        HELP   => 'Number of old profiles to keep before purging',
+    },
+
+    {
+        option => 'purge_time',
+        suffix => '=i',
+        DEFAULT => 86400,
+        HELP   => 'Number of seconds before purging inactive profiles',
+    },
+
+    {
+        option => 'json_typed',
+        DEFAULT => 0,
+        HELP => 'Extract typed data from JSON profiles',
+    },
+
+    {
+        option => 'debug',
+        suffix => '|d=i',
+        HELP => 'Turn on debugging messages',
+    },
+
+    {
+        option => 'base_url',
+        suffix => '=s',
+        HELP => 'Base url to use when the profile is relative',
+    },
+);
+
+Readonly::Array our @CFG_KEYS => sort map {$_->{option}} @CONFIG_OPTIONS;
+
+push(@EXPORT_OK, qw(@CONFIG_OPTIONS $CONFIG_FN @CFG_KEYS));
 
 # Holds the default and all possible keys
-Readonly::Hash my %DEFAULT_CFG => {
-    "base_url"         => undef,
-    "ca_dir"           => undef,
-    "ca_file"          => undef,
-    "cache_root"       => "/var/lib/ccm",
-    "cert_file"        => undef,
-    "context"          => undef,
-    "dbformat"         => "GDBM_File",
-    "debug"            => undef,
-    "force"            => undef,
-    "get_timeout"      => 30,
-    "json_typed"       => 0,
-    "keep_old"         => 2,
-    "key_file"         => undef,
-    "lock_retries"     => 3,
-    "lock_wait"        => 30,
-    "preprocessor"     => undef,
-    "profile"          => undef,
-    "profile_failover" => undef,
-    "purge_time"       => 86400,
-    "retrieve_retries" => 3,
-    "retrieve_wait"    => 30,
-    "trust"            => undef,
-    "world_readable"   => undef,
-};
+Readonly::Hash my %DEFAULT_CFG =>
+    map {$_->{option} => $_->{DEFAULT}} @CONFIG_OPTIONS;
 
-Readonly::Array our @CFG_KEYS => sort(keys(%DEFAULT_CFG));
-
-push(@EXPORT_OK, qw(@CFG_KEYS));
 
 # copy hash to hash ref
+# TODO this is a global config instance,
+# there is no support for multiple configfiles
 my $cfg = {%DEFAULT_CFG};
+
+
+# Hash ref that hold configuration files that will be forced,
+# even when re-reading the config file
+my $force_cfg = {};
 
 sub _resolveTags ($)
 {
@@ -105,19 +244,25 @@ sub _resolveTags ($)
     return $s;
 }
 
+# This format is "<key> <value>" and is readable by AppConfig
+# But lots of AppConfig file format features
+# are not supported with this reader.
 sub _readConfigFile ($)
 {
     my ($fn) = @_;
 
     my $fh = CAF::FileReader->new($fn);
-        
+
     foreach my $line (split ("\n", "$fh")) {
         next if ($line =~ m/^\s*(\#|$)/);
         if ($line =~ m/^\s*(\w+)\s+(\S+)\s*$/) {
             my $var = $1;
             my $val = $2;
             if (exists($DEFAULT_CFG{$var})) {
-                if (   $var eq 'profile'
+                if (exists $force_cfg->{$var}) {
+                    # Force the values
+                    $cfg->{$var} = $force_cfg->{$var};
+                } elsif (   $var eq 'profile'
                     or $var eq 'profile_failover'
                     or $var eq 'context')
                 {
@@ -165,14 +310,14 @@ sub initCfg
             return ();
         }
     } else {
-        if (-f "/etc/$CONFIG_FN") {
-            $cp = "/etc/$CONFIG_FN";
-        } elsif (-f $DEF_EDG_LOC . "/etc/$CONFIG_FN") {
-            $cp = $DEF_EDG_LOC . "/etc/$CONFIG_FN";
+        if (-f $CONFIG_FN) {
+            $cp = $CONFIG_FN;
+        } elsif (-f $DEF_EDG_LOC . $CONFIG_FN) {
+            $cp = $DEF_EDG_LOC . $CONFIG_FN;
         } elsif (defined($ENV{"EDG_LOCATION"})
-            && -f $ENV{"EDG_LOCATION"} . "/etc/$CONFIG_FN")
+            && -f $ENV{"EDG_LOCATION"} . $CONFIG_FN)
         {
-            $cp = $ENV{"EDG_LOCATION"} . "/etc/$CONFIG_FN";
+            $cp = $ENV{"EDG_LOCATION"} . $CONFIG_FN;
         } else {
             #no default configuration file exists
             #default parameters values will be used
@@ -199,10 +344,11 @@ sub getCfgValue ($)
 }
 
 # private method to set values, for testing only
+# throws an error on unknown key
 sub _setCfgValue
 {
     my ($key, $value) = @_;
-    if (defined($cfg->{$key})) {
+    if (exists($cfg->{$key})) {
         $cfg->{$key} = $value;
     } else {
         throw_error("Not a valid config key $key");

--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -17,7 +17,7 @@ use parent qw(Exporter);
 use Readonly;
 
 our @EXPORT    = qw();
-our @EXPORT_OK = qw(initCfg getCfgValue);
+our @EXPORT_OK = qw(initCfg getCfgValue setCfgValue resetCfg);
 our $VERSION   = '${project.version}';
 
 =head1 NAME
@@ -211,6 +211,43 @@ sub _setCfgValue
     return getCfgValue($key);
 }
 
+=item setCfgValue ($key, $value, $force)
+
+Set the configuration option C<$key> to C<$value>.
+If force is set, the option and value are also added
+to the C<force_cfg> hashref, making it protected against
+rereading of the config file.
+
+=cut
+
+sub setCfgValue
+{
+    my ($key, $value, $force) = @_;
+    my $newvalue = _setCfgValue($key, $value);
+
+    # _setCfgValue throws error on unknown key
+
+    if ($force) {
+        $force_cfg->{$key} = $value;
+    }
+
+    # for unittesting
+    return $newvalue;
+}
+
+=item resetCfg
+
+reset the configuration hash and empty the force
+hashref.
+
+=cut
+
+sub resetCfg
+{
+    $cfg = {%DEFAULT_CFG};
+    $force_cfg = {};
+}
+
 =pod
 
 =back
@@ -218,4 +255,3 @@ sub _setCfgValue
 =cut
 
 1;
-

--- a/src/main/perl/Configuration.pm
+++ b/src/main/perl/Configuration.pm
@@ -400,6 +400,27 @@ sub elementExists
     return $ex;
 }
 
+=item getTree ($path)
+
+returns C<getTree> of the element identified by C<$path>.
+Any other optional arguments are passed to C<getTree>.
+
+If the path does not exist, undef is returned.
+
+=cut
+
+sub getTree
+{
+    my ($self, $path, @args) = @_;
+
+    return if (! $self->elementExists($path));
+
+    my $el = $self->getElement($path);
+    return if(! $el);
+
+    return $el->getTree(@args);
+}
+
 =pod
 
 =back

--- a/src/main/perl/Element.pm
+++ b/src/main/perl/Element.pm
@@ -572,6 +572,7 @@ Array ref of anonymous methods to convert the argument
 
 The arrayref of anonymous methods are applied as follows: 
 convert methods C<[a, b, c]> will produce C<$new = c(b(a($old)))>.
+(An exception is thrown if these methods are not code references).
 
 =cut
 

--- a/src/main/perl/Options.pm
+++ b/src/main/perl/Options.pm
@@ -1,0 +1,287 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+package EDG::WP4::CCM::Options;
+
+use strict;
+use warnings;
+
+use CAF::Application qw($OPTION_CFGFILE);
+use CAF::Reporter;
+use LC::Exception qw(SUCCESS);
+use EDG::WP4::CCM::CCfg qw(@CONFIG_OPTIONS $CONFIG_FN setCfgValue);
+use EDG::WP4::CCM::Element qw(escape);
+use Readonly;
+
+our @ISA = qw(CAF::Application CAF::Reporter);
+
+Readonly::Hash my %PATH_SELECTION_METHODS => {
+    profpath => {
+        help => 'profile path',
+        method => sub { return $_[0]; },
+    },
+    component => {
+        help => 'component',
+        method => sub { return "/software/components/". $_[0]; },
+    },
+    metaconfig => {
+        help => 'metaconfig service',
+        method => sub { return "/software/components/metaconfig/services/". escape($_[0]) . "/contents"; },
+    },
+};
+
+Readonly::Hash my %ACTIONS => {
+    showcids => 'Show valid CIDs',
+};
+
+=head1 NAME
+
+EDG::WP4::CCM::Options
+
+=head1 DESCRIPTION
+
+Use this module to create (commandline) application that interact with CCM directly.
+
+Available convenience methods:
+
+=over
+
+=cut
+
+
+# initialize
+sub _initialize {
+
+    my $self = shift;
+
+    # version and usage
+    $self->{'VERSION'} = "${project.version}";
+    $self->{'USAGE'}   = sprintf("Usage: %s [OPTIONS...]", $0);
+
+    # initialise
+    unless ($self->SUPER::_initialize(@_)) {
+        return undef;
+    }
+
+    return SUCCESS;
+}
+
+=item app_options
+
+Return list of CCM application specific options and
+commandline options for all CCM config options
+
+=cut
+
+sub app_options {
+
+    my @options = (
+        {
+            # the ccm client will use the main ccm.conf from CCfg
+            NAME    => "$OPTION_CFGFILE=s",
+            DEFAULT => $CONFIG_FN,
+            HELP    => 'configuration file for CCM',
+        },
+
+        {
+            NAME    => "cid=s",
+            HELP    => "set configuration CID (default 'undef' is the current CID; see CCM::CacheManager getCid for special values)",
+        },
+
+    );
+
+    # Actions
+    foreach my $act (sort keys %ACTIONS) {
+        push(@options, {
+             NAME => "$act",
+             HELP => $PATH_SELECTION_METHODS{$act},
+             });
+    }
+
+    # profile path selection options
+    foreach my $sel (sort keys %PATH_SELECTION_METHODS) {
+        push(@options, {
+             NAME => "$sel=s@",
+             HELP => "Select the ".$PATH_SELECTION_METHODS{$sel}->{help}."(s)",
+             });
+    }
+
+    # Add support for all CCfg CONFIG_OPTIONS
+    foreach my $opt (@CONFIG_OPTIONS) {
+        # don't modify the original hasrefs
+        my $newopt = {
+            NAME => $opt->{option},
+            HELP => $opt->{HELP},
+        };
+
+        $newopt->{NAME} .= $opt->{suffix} if exists($opt->{suffix});
+        $newopt->{DEFAULT} .= $opt->{DEFAULT} if exists($opt->{DEFAULT});
+
+        push(@options, $newopt);
+    }
+
+    return \@options;
+}
+
+
+=item setCCMConfig
+
+Set the CCM Configuration instance for CID C<cid> under CCM_CONFIG attribute
+using CacheManager's C<getConfiguration> method.
+
+If C<cid> is not defined, the C<cid> value from the C<--cid>-option will be used.
+(To use the current CID when another cid value set via C<--cid>-option, pass an empty
+string or the string 'current').
+
+A CacheManager instance under CACHEMGR attribute is created if none exists
+or C<force_cache> is set to true.
+
+Returns SUCCESS on success, undef on failure.
+
+=cut
+
+sub setCCMConfig
+{
+    my ($self, $cid, $force_cache) = @_;
+
+    my $msg;
+
+    if((! defined($self->{CACHEMGR})) || $force_cache) {
+        my $configfile = $self->option($OPTION_CFGFILE);
+        my $cacheroot = $self->option('cache_root');
+
+        # The CCM::CacheManager->new() does CCfg::initCfg
+        # but we need to pass/redefine the relevant commandline options too.
+        # TODO: what a mess
+        # TODO: is there a way to only set the values defined on commandline?
+        foreach my $opt (@CONFIG_OPTIONS) {
+            my $option = $opt->{option};
+            # force them to protect against (re)reading (e.g. in Fetch)
+            setCfgValue($option, $self->option($option), 1);
+        }
+
+        $msg = "cache manager with cacheroot $cacheroot and configfile $configfile";
+        $self->verbose("Accessing CCM $msg.");
+        $self->{CACHEMGR} = EDG::WP4::CCM::CacheManager->new($cacheroot, $configfile);
+        unless (defined $self->{'CACHEMGR'}) {
+            throw_error ("Cannot access $msg.");
+            return;
+        }
+    }
+
+    $cid = $self->option('cid') if(! defined($cid));
+
+    $msg = "for CID ". (defined($cid) ? $cid : "<undef>");
+    $self->verbose("getting CCM configuration $msg.");
+    $self->{CCM_CONFIG} = $self->{CACHEMGR}->getConfiguration(undef, $cid);
+    unless (defined $self->{CCM_CONFIG}) {
+        throw_error ("Cannot get configuration via CCM $msg.");
+        return;
+    }
+
+    return SUCCESS;
+}
+
+=item getCCMConfig
+
+returns the CCM configuration instance
+
+=cut
+
+sub getCCMConfig
+{
+    my $self = shift;
+    return $self->{CCM_CONFIG};
+}
+
+=item gatherPaths
+
+Retrun arrayref of selected profile path (via the PATH_SELECTION_METHODS)
+
+=cut
+
+sub gatherPaths
+{
+    my $self = shift;
+
+    my @paths;
+    # profile path selection options
+    foreach my $sel (sort keys %PATH_SELECTION_METHODS) {
+        my $values = $self->option($sel);
+        my $method = $PATH_SELECTION_METHODS{$sel}->{method};
+        if (defined($values)) {
+            foreach my $val (@$values) {
+                push(@paths, $method->($val))
+            }
+        }
+    }
+    return \@paths;
+}
+
+# wrapper around print (for easy unittesting)
+sub _print
+{
+    my ($self, @args) = @_;
+    print @_;
+}
+
+=item action_showcids
+
+the showcids action prints all sorted profile CIDs as comma-separated list
+
+=cut
+
+sub action_showcids
+{
+    my $self = shift;
+
+    $self->setCCMConfig();
+
+    my $cids = $self->{CACHEMGR}->getCids();
+
+    $self->_print(join(',', @$cids), "\n");
+
+    return SUCCESS;
+}
+
+=item action
+
+Run first of the predefined actions via the action_<actionname> methods
+
+=cut
+
+sub action
+{
+    my $self = shift;
+
+    # defined actions
+    my @acts = map {$_ if $self->option($_)} sort keys %ACTIONS;
+    my $act;
+
+    # very primitive for now: run first found
+    if (@acts && $acts[0] =~ m/^(\w+)$/) {
+        $act = $1;
+    }
+
+    if ($act) {
+        my $method = $self->can("action_$act");
+        return if(! $method);
+
+        # execute it
+        return $method->($self);
+    }
+
+    # return SUCCESS if no actions selected (nothing goes wrong)
+    return SUCCESS;
+}
+
+=pod
+
+=back
+
+=cut
+
+
+1;

--- a/src/test/perl/options.t
+++ b/src/test/perl/options.t
@@ -1,0 +1,116 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Quattor::ProfileCache qw(prepare_profile_cache);
+use EDG::WP4::CCM::Options;
+use EDG::WP4::CCM::CCfg qw(@CONFIG_OPTIONS $CONFIG_FN);
+use EDG::WP4::CCM::Element qw(escape);
+use Test::MockModule;
+
+my $optmock = Test::MockModule->new('EDG::WP4::CCM::Options');
+
+my $apppath = "target/sbin/ccm";
+my $opts = EDG::WP4::CCM::Options->new(
+    $apppath,
+    '--cfgfile', 'src/test/resources/ccm.cfg',
+    );
+
+isa_ok($opts, "EDG::WP4::CCM::Options",
+       "EDG::WP4::CCM::Options instance created");
+
+my $options = $opts->app_options();
+my %optshash = map { $_->{NAME} => $_->{DEFAULT} } @$options;
+
+my $custom = {
+    'cfgfile=s' => $CONFIG_FN,
+    'cid=s' => undef,
+    'showcids' => undef,
+    'profpath=s@' => undef,
+    'component=s@' => undef,
+    'metaconfig=s@' => undef,
+};
+foreach my $opt (@CONFIG_OPTIONS) {
+    $custom->{$opt->{option}.($opt->{suffix} || '')} = $opt->{DEFAULT};
+}
+
+is_deeply(\%optshash, $custom, "Found expected options and defaults");
+
+# verify values read from ccm.cfg
+
+my $ccmcfgopts = {
+    debug => 0,
+    get_timeout => 1,
+    profile => 'https://www.google.com',
+    cache_root => 'target/test/cache',
+    retrieve_wait => 0,
+    retrieve_retries => 1,
+};
+
+foreach my $k (sort keys %$ccmcfgopts) {
+    my $v = $ccmcfgopts->{$k};
+    is($opts->option($k), $v, "$k value $v in ccm.cfg");
+};
+
+# Actually test a CCM app instance using existing CCM
+# Cannot use Test::Quattor import due to CAF mocking
+my $ppc_cfg = prepare_profile_cache('options');
+
+# --cid is not really tested as latest, current and most recent are all the same profile
+my $newopts = EDG::WP4::CCM::Options->new(
+    $apppath,
+    '--cfgfile', 'src/test/resources/ccm.cfg',
+    '--cache_root', $ppc_cfg->{cache_path},
+    '--cid', "latest", # use latest CID as defined in the latest.cid file
+    '--profpath', '/a/b/c', '--profpath', '/d/e/f',
+    '--metaconfig', '/etc/special', '--metaconfig', '/etc/veryspecial',
+    '--component', 'mycomponent', '--component', 'othercomponent',
+    );
+isa_ok($newopts, "EDG::WP4::CCM::Options",
+       "EDG::WP4::CCM::Options instance created");
+ok($newopts->setCCMConfig(), "Created the CCM config (no cid passed)");
+
+isa_ok($newopts->{CACHEMGR}, "EDG::WP4::CCM::CacheManager",
+       "CACHEMGR attribute returns EDG::WP4::CCM::CacheManager instance");
+isa_ok($newopts->{CCM_CONFIG}, "EDG::WP4::CCM::Configuration",
+       "CCM_CONFIG attribute returns EDG::WP4::CCM::Configuration instance");
+
+my $cfg = $newopts->getCCMConfig();
+isa_ok($cfg, "EDG::WP4::CCM::Configuration",
+       "getCCMConfig returns EDG::WP4::CCM::Configuration instance");
+is($cfg, $newopts->{CCM_CONFIG}, "getCCMConfig returns expected instance");
+
+# Check data
+is_deeply($cfg->getTree("/"), {a => 'b'}, "Read CCM returns correct data");
+
+# gatherPaths: option name sorted
+is_deeply($newopts->gatherPaths(),
+          ['/software/components/mycomponent', # component
+           '/software/components/othercomponent',
+           '/software/components/metaconfig/services/'. escape('/etc/special') ."/contents", # metaconfig
+           '/software/components/metaconfig/services/'. escape('/etc/veryspecial') . "/contents",
+           '/a/b/c', # profpath
+           '/d/e/f',
+          ],
+          "Expected gatherPaths");
+
+# showcids action
+my @print;
+$optmock->mock('_print', sub {shift; @print = @_;});
+
+my $showcids = EDG::WP4::CCM::Options->new(
+    $apppath,
+    '--cfgfile', 'src/test/resources/ccm.cfg',
+    '--cache_root', $ppc_cfg->{cache_path},
+    '--showcids',
+    );
+isa_ok($showcids, "EDG::WP4::CCM::Options",
+       "EDG::WP4::CCM::Options instance created");
+
+# hmm, there's only one (so no comma-join is tested)
+ok($showcids->action(), "action with showcids returns success");
+is_deeply(\@print, [2, "\n"], "showcids gives correct result");
+
+$optmock->unmock('_print');
+
+done_testing();

--- a/src/test/perl/test-cachemanager.t
+++ b/src/test/perl/test-cachemanager.t
@@ -15,11 +15,21 @@ use Test::More;
 use CCMTest qw (eok make_file);
 use LC::Exception qw(SUCCESS);
 use LC::File qw (differ);
-use EDG::WP4::CCM::CacheManager qw ($DATA_DN $GLOBAL_LOCK_FN 
-				      $CURRENT_CID_FN $LATEST_CID_FN);
+use EDG::WP4::CCM::CacheManager qw ($DATA_DN $GLOBAL_LOCK_FN
+				      $CURRENT_CID_FN $LATEST_CID_FN
+                      $PROFILE_DIR_N);
 use EDG::WP4::CCM::SyncFile qw ();
+use Test::MockModule;
 
 use Cwd;
+
+# check exported readonly
+is($DATA_DN, "data", "DATA_DN exported and expected value");
+is($GLOBAL_LOCK_FN, "global.lock", "GLOBAL_LOCK_FN exported and expected value");
+is($CURRENT_CID_FN, "current.cid", "CURRENT_CID_FN exported and expected value");
+is($LATEST_CID_FN, "latest.cid", "LATEST_CID_FN exported and expected value");
+is($PROFILE_DIR_N, "profile.", "PROFILE_DIR_N exported and expected value");
+
 
 my $ec = LC::Exception::Context->new->will_store_errors;
 my $cptmp = getcwd()."/target/tmp";
@@ -27,20 +37,20 @@ my $cp = "$cptmp/cm-test";
 
 mkdir($cptmp) if (! -d $cptmp);
 
-eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"), 
+eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"),
      "EDG::WP4::CCM::CacheManager->new (foo)");
 
 #create dir and file structure
 
 ok(! -d $cp, "cache manager test dir $cp does not yet exist.");
 
-eok ($ec, EDG::WP4::CCM::CacheManager::_check_type("directory", $cp, $cp), 
+eok ($ec, EDG::WP4::CCM::CacheManager::_check_type("directory", $cp, $cp),
      "CacheManager::_check_type(directory, $cp)");
 
 mkdir($cp);
 ok(-d $cp, "cache manager test dir $cp exists.");
 
-ok (EDG::WP4::CCM::CacheManager::_check_type("directory", $cp, $cp), 
+ok (EDG::WP4::CCM::CacheManager::_check_type("directory", $cp, $cp),
      "CacheManager::_check_type(directory, $cp)");
 
 mkdir("$cp/$DATA_DN");
@@ -48,17 +58,17 @@ mkdir("$cp/$DATA_DN");
 my $ccidfn = "$cp/$CURRENT_CID_FN";
 my $lcidfn = "$cp/$LATEST_CID_FN";
 
-eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"), 
+eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"),
      "EDG::WP4::CCM::CacheManager->new (foo)");
 
 make_file("$cp/$GLOBAL_LOCK_FN", "no\n");
 
-eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"), 
+eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"),
      "EDG::WP4::CCM::CacheManager->new (foo)");
 
 make_file($ccidfn, "1\n");
 
-eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"), 
+eok ($ec, EDG::WP4::CCM::CacheManager->new ("foo"),
      "EDG::WP4::CCM::CacheManager->new (foo)");
 
 eok ($ec, EDG::WP4::CCM::CacheManager::_check_type("file", $lcidfn, $lcidfn),
@@ -71,7 +81,7 @@ ok (EDG::WP4::CCM::CacheManager::_check_type("file", $lcidfn, $lcidfn),
 
 my $cm;
 
-ok ($cm = EDG::WP4::CCM::CacheManager->new ($cp), 
+ok ($cm = EDG::WP4::CCM::CacheManager->new ($cp),
      "EDG::WP4::CCM::CacheManager->new ($cp)");
 
 is ($cm->isLocked(), 0, '$cm->isLocked() false');
@@ -90,7 +100,7 @@ make_file("$cp/test_yes", "yes\n");
 make_file("$cp/test_no", "no\n");
 
 my $ccidf;
-ok ($ccidf = EDG::WP4::CCM::SyncFile->new("$ccidfn"), 
+ok ($ccidf = EDG::WP4::CCM::SyncFile->new("$ccidfn"),
     "SyncFile->new($ccidf)");
 my $lcidf;
 ok ($lcidf = EDG::WP4::CCM::SyncFile->new("$lcidfn"),
@@ -99,6 +109,9 @@ ok ($lcidf = EDG::WP4::CCM::SyncFile->new("$lcidfn"),
 $ccidf->write ("1");
 $lcidf->write ("2");
 
+is ($cm->getCurrentCid(), 1, '$cm->getCurrentCid() == 2');
+is ($cm->getLatestCid(), 2, '$cm->getLatestCid() == 2');
+
 #old unlock test
 #  implied set_ccid_to_lcid
 make_file("$cp/$GLOBAL_LOCK_FN", "no\n");
@@ -106,6 +119,7 @@ $ccidf->write ($lcidf->read());
 
 is ($cm->isLocked(), 0, '$cm->isLocked() false');
 is ($cm->getCurrentCid(), 2, '$cm->getCurrentCid() == 2');
+is ($cm->getLatestCid(), 2, '$cm->getLatestCid() == 2');
 
 eok ($ec, $cm->getLockedConfiguration (0), '$cm->getLockedConfiguration (0)');
 
@@ -113,6 +127,8 @@ mkdir("$cp/profile.1");
 mkdir("$cp/profile.2");
 ok(-d "$cp/profile.1", "cache manager profile.1 dir exists.");
 ok(-d "$cp/profile.2", "cache manager profile.2 dir exists.");
+
+is_deeply($cm->getCids(), [1, 2], "getCids returns expected sorted list of cids");
 
 my ($cfg, $pidfile);
 ok ($cfg = $cm->getAnonymousConfiguration (0), '$cm->getAnonymousConfiguration (0)');
@@ -146,9 +162,48 @@ mkdir("$cp/profile.4");
 ok(-d "$cp/profile.3", "cache manager profile.3 dir exists.");
 ok(-d "$cp/profile.4", "cache manager profile.4 dir exists.");
 
+is_deeply($cm->getCids(), [1, 2, 3 ,4], "getCids returns expected sorted list of cids");
+
+is ($cm->getCurrentCid(), 2, '$cm->getCurrentCid() == 2 (unmodified)');
+is ($cm->getLatestCid(), 2, '$cm->getLatestCid() == 2 (unmodified)');
+
 # current = 3; latest = 4
 $ccidf->write ("3");
 $lcidf->write ("4");
+
+my $ccid = $cm->getCurrentCid();
+my $lcid = $cm->getLatestCid();
+is ($ccid, 3, '$cm->getCurrentCid() == 3');
+is ($lcid, 4, '$cm->getLatestCid() == 4');
+# important for getCid tests to distinguish results)
+ok($ccid != $lcid, "Current CID is not equal to latest CID");
+
+# most recent 6
+# is a directory without updating latest (should not happen in real)
+my $mcid = 6;
+mkdir("$cp/profile.$mcid");
+ok(-d "$cp/profile.$mcid", "cache manager profile.6 dir exists.");
+
+is_deeply($cm->getCids(), [1, 2, 3 ,4, 6], "getCids returns expected sorted list of cids");
+
+# test getCid method
+is($cm->getCid(), $ccid, "getCid returns current CID with no arg (=undef)");
+is($cm->getCid(undef), $ccid, "getCid returns current CID with undef");
+is($cm->getCid(''), $ccid, "getCid returns current CID with empty string");
+is($cm->getCid('current'), $ccid, "getCid returns current CID with 'current' string");
+
+is($cm->getCid('latest'), $lcid, "getCid returns latest CID with 'latest' string");
+is($cm->getCid('-'), $lcid, "getCid returns latest CID with '-' string");
+
+is($cm->getCid(1), 1, "getCid returns CID=1 with arg 1");
+is($cm->getCid(7), undef, "getCid returns undef with arg 7 (non-existing CID)");
+is($cm->getCid("woohoo"), undef, "getCid returns undef with arg woohoo (non-existing CID)");
+
+is($cm->getCid(-1), $mcid, "getCid returns most recent with arg -1");
+# not really $mcid-2, but there happens to be a gap (5 is missing)
+is($cm->getCid(-2), $mcid-2, "getCid returns 2nd most recent with arg -2");
+
+is($cm->getCid(-6), undef, "getCid returns undef with arg -6 (there's no 6th most recent CID)");
 
 #$cm->lock();
 make_file("$cp/$GLOBAL_LOCK_FN", "yes\n");
@@ -162,10 +217,61 @@ $ccidf->write ($lcidf->read());
 
 ok ($cfg = $cm->_getConfig (0, 0), '$cfg->_getConfig (0, 0)');
 is ($cfg->getConfigurationId(), 4, '$cfg->getConfigurationId() == 4');
-ok ($lcidf->read() == 4 && $ccidf->read() == 4, 
+ok ($lcidf->read() == 4 && $ccidf->read() == 4,
     "current.cid == 4 && latest.cid == 4");
 
 make_file("$cp/td.txt", "1\n");
 my $url = "file:///$cp/td.txt";
+
+# Test the getConfiguration method by checking the arguments
+mkdir("$cp/profile.5");
+ok(-d "$cp/profile.5", "cache manager profile.5 dir exists.");
+$lcidf->write ("5");
+
+# passed to _getConfig
+my $args_getConfig;
+my $cred; # does nothing
+
+# update it to current current CID
+$ccid = $cm->getCurrentCid();
+$lcid = $cm->getLatestCid();
+is ($ccid, 4, '$cm->getCurrentCid() == 4');
+is ($lcid, 5, '$cm->getLatestCid() == 5');
+
+my $mock = Test::MockModule->new('EDG::WP4::CCM::CacheManager');
+$mock->mock('_getConfig', sub {
+    shift;
+    $args_getConfig = \@_;
+    return 1;
+});
+
+$cm->getConfiguration($cred);
+is_deeply($args_getConfig, [0, $cred, $ccid, -1],
+          "expected arguments for undefined cid");
+
+$cm->getConfiguration($cred, 2);
+is_deeply($args_getConfig, [1, $cred, 2, -1],
+          "expected arguments for defined cid");
+
+$cm->getConfiguration($cred, -1);
+is_deeply($args_getConfig, [1, $cred, $mcid, -1],
+          "expected arguments for cid == -1");
+
+$cm->getConfiguration($cred, undef, locked => 1, anonymous => 1);
+is_deeply($args_getConfig, [1, $cred, $ccid, 1],
+          "expected arguments for undefined cid with forced locked and anonymous");
+
+$cm->getConfiguration($cred, 2, locked => 0, anonymous => 1);
+is_deeply($args_getConfig, [0, $cred, 2, 1],
+          "expected arguments for defined cid with forced locked and anonymous");
+
+# cid == -1 gets resolved to most recent via getCid
+$cm->getConfiguration($cred, -1, locked => 0, anonymous => 0);
+is_deeply($args_getConfig, [0, $cred, $mcid, 0],
+          "expected arguments for cid == -1 with forced locked and anonymous");
+
+
+$mock->unmock('_getConfig');
+
 
 done_testing();

--- a/src/test/perl/test-element.t
+++ b/src/test/perl/test-element.t
@@ -75,7 +75,7 @@ sub gen_dbm ($$) {
     # description
     $key = 0x40000001;
     $hash{pack("L", $key)} = "an example of string";
-    
+
     # value
     $key = 0x00000002;
     $hash{pack("L", $key)} = "a list";
@@ -120,65 +120,60 @@ $config = EDG::WP4::CCM::Configuration->new($cm, 1, 1);
 # create element with string path
 $path = "/path/to/property";
 $element = EDG::WP4::CCM::Element->new($config, $path);
-ok(defined($element) && UNIVERSAL::isa($element, "EDG::WP4::CCM::Element"),
-   "Element->new(config, string)");
+isa_ok($element, "EDG::WP4::CCM::Element",
+       "Element->new(config, string) is a EDG::WP4::CCM::Element instance");
 
 # create element with Path object
 $path = EDG::WP4::CCM::Path->new("/path/to/property");
 $element = EDG::WP4::CCM::Element->new($config, $path);
-ok(defined($element) && UNIVERSAL::isa($element, "EDG::WP4::CCM::Element"),
-   "Element->new(config, Path)");
+isa_ok($element, "EDG::WP4::CCM::Element",
+       "Element->new(config, Path) is a EDG::WP4::CCM::Element instance");
 
 # create resource with createElement()
 $path = EDG::WP4::CCM::Path->new("/path/to/resource");
 $element = EDG::WP4::CCM::Element->createElement($config, $path);
-ok(defined($element) && UNIVERSAL::isa($element, "EDG::WP4::CCM::Resource"),
-   "Element->createElement(config, Path_to_resource)");
+isa_ok($element, "EDG::WP4::CCM::Resource",
+       "Element->createElement(config, Path_to_resource) is a EDG::WP4::CCM::Resource instance");
 
 # create property with createElement()
 $path = EDG::WP4::CCM::Path->new("/path/to/property");
 $element = EDG::WP4::CCM::Element->createElement($config, $path);
-ok(defined($element) && UNIVERSAL::isa($element, "EDG::WP4::CCM::Property"),
-   "Element->createElement(config, Path_to_property)");
-
-# test getConfiguration()
-$config = $element->getConfiguration();
-$prof_dir  = $config->getConfigPath();
-ok($prof_dir eq "$cache_dir/$profile", "Element->getConfiguration()");
+isa_ok($element, "EDG::WP4::CCM::Property",
+       "Element->createElement(config, Path_to_property) is a EDG::WP4::CCM::Property instance");
 
 # test getEID()
 $eid = $element->getEID();
-ok($eid == 1, "Element->getEID()");
+is($eid, 1, "Element->getEID() 1");
 
 # test getName()
 $name = $element->getName();
-ok($name eq "property", "Element->getName()");
+is($name, "property", "Element->getName()");
 
 # test getPath()
 $path = $element->getPath();
 $string = $path->toString();
-ok($string eq "/path/to/property", "Element->getPath()");
+is($string, "/path/to/property", "Element->getPath()");
 
 # test getType()
 $type = $element->getType();
-ok($type == EDG::WP4::CCM::Element->STRING, "Element->getType()" );
+is($type, EDG::WP4::CCM::Element->STRING, "Element->getType()" );
 
 # test getDerivation()
 $derivation = $element->getDerivation();
-ok($derivation eq "lxplus.tpl,hardware.tpl,lxplust_025.tpl",
+is($derivation, "lxplus.tpl,hardware.tpl,lxplust_025.tpl",
    "Element->getDerivation()");
 
 # test getChecksum()
 $checksum = $element->getChecksum();
-ok($checksum eq md5_hex($derivation), "Element->getChecksum()");
+is($checksum, md5_hex($derivation), "Element->getChecksum()");
 
 # test getDescription()
 $description = $element->getDescription();
-ok($description eq "an example of string", "Element->getDescription()");
+is($description, "an example of string", "Element->getDescription()");
 
 # test getValue()
 $value = $element->getValue();
-ok($value eq "a string", "Element->getValue()");
+is($value, "a string", "Element->getValue()");
 
 # test isType()
 ok($element->isType(EDG::WP4::CCM::Element->STRING),
@@ -199,5 +194,38 @@ ok(!$element->isResource(),   "!Element->isResource()");
 
 # test isProperty()
 ok($element->isProperty(),   "Element->isProperty()");
+
+#
+# Test CCM::Configuration instance methods
+#
+
+# test getConfiguration()
+$config = $element->getConfiguration();
+$prof_dir  = $config->getConfigPath();
+is($prof_dir, "$cache_dir/$profile", "Element->getConfiguration()");
+
+$path = $element->getPath();
+
+my $preppath = $config->_prepareElement("$path");
+isa_ok($preppath, "EDG::WP4::CCM::Path",
+       "_prepareElement returns EDG::WP4::CCM::Path instance");
+is("$preppath", "$path", "_prepareElement path has expected value");
+
+ok($config->elementExists("$path"), "config->elementExists true for path $path");
+ok(! $config->elementExists("/fake$path"), "config->elementExists false for path /fake$path");
+
+my $cfg_el = $config->getElement("$path");
+my $pathdata = 'a string';
+
+isa_ok($cfg_el, "EDG::WP4::CCM::Element",
+       "config->getElement returns EDG::WP4::CCM::Element instance");
+# is a property, not a hash or list
+is($cfg_el->getValue(), $pathdata, "getVale from element instance as expected");
+is_deeply($cfg_el->getTree(), $pathdata, "getTree from element instance as expected");
+
+is($config->getValue("$path"), $pathdata, "config->getValue of $path as expected");
+# is a property, not a hash or list
+is_deeply($config->getTree("$path"), $pathdata, "config->getTree of $path as expected");
+ok(! defined($config->getTree("/fake$path")), "config->getTree of /fake$path undefined");
 
 done_testing();

--- a/src/test/resources/options.pan
+++ b/src/test/resources/options.pan
@@ -1,0 +1,3 @@
+object template options;
+
+"/a" = "b";


### PR DESCRIPTION
Improve CCM API by clarifying the Configuration initialisation, introduce a smarter `CacheManager->getConfiguration()` or obtain a `Configuration` instance and a `CCM::Options` class derived from `CAF::Options` to create command applications.