### PR TITLE
support for multiple profile failover urls

### DIFF
--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -62,7 +62,7 @@ Readonly::Array our @CONFIG_OPTIONS => (
     {
         option => 'profile_failover',
         suffix => '=s',
-        HELP => 'URL of profile to fetch when --profile is not available',
+        HELP => 'URL of profile to fetch when --profile is not available, can be comma separated',
     },
 
     {

--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -329,7 +329,11 @@ sub download
 
     my @st = stat($cache) or die "Unable to stat profile cache: $cache ($!)";
 
-    foreach my $u (($url, $self->{uc($type) . "_FAILOVER"})) {
+    my @urls = ($url);
+    push @urls, split(/,/, $self->{uc($type) . "_FAILOVER"})
+        if defined($self->{uc($type) . "_FAILOVER"});
+
+    foreach my $u (@urls) {
         next if (!defined($u));
         for my $i (1 .. $self->{RETRIEVE_RETRIES}) {
             my $rt = $self->retrieve($u, $cache, $st[ST_MTIME]);

--- a/src/test/perl/fetch.t
+++ b/src/test/perl/fetch.t
@@ -13,7 +13,7 @@ Script that tests the EDG::WP4::CCM::Fetch module.
 
 use strict;
 use warnings;
-use Test::More tests => 63;
+use Test::More tests => 64;
 use EDG::WP4::CCM::Fetch qw($GLOBAL_LOCK_FN $FETCH_LOCK_FN
     $CURRENT_CID_FN $LATEST_CID_FN $DATA_DN
     $TABCOMPLETION_FN
@@ -239,6 +239,17 @@ and the function will thus succeed.
 $f->{PROFILE_FAILOVER} = $url;
 $pf = $f->download("profile");
 isnt($pf, undef, "Non-existing URL with a failover retrieves something");
+
+=pod
+
+Multiple comma seperated failover URLs are supported. Try two failovers,
+the first of which doesn't work.
+
+=cut
+
+$f->{PROFILE_FAILOVER} = "http://afjbsabfaf.fadsfsagfsagagf.org,$url";
+$pf = $f->download("profile");
+isnt($pf, undef, "Non-existing URL with a non-existing first failover retrieves something");
 
 =pod
 


### PR DESCRIPTION
Hi,

We would like to make use of multiple failover URLs, by making the profile_failover setting comma seperated.