### PR TITLE
Mark /etc/ccm.conf as noreplace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
             <username>root</username>
             <groupname>root</groupname>
             <filemode>644</filemode>
-            <configuration>true</configuration>
+            <configuration>noreplace</configuration>
             <documentation>false</documentation>
             <directoryIncluded>false</directoryIncluded>
             <sources>


### PR DESCRIPTION
Existing configurations may be lost.  According to http://www.mojohaus.org/rpm-maven-plugin/map-params.html this value should mark noreplace explicitly.