### PR TITLE
Use valid defaults for host and domain in default config file

### DIFF
--- a/src/main/conf/ccm.conf
+++ b/src/main/conf/ccm.conf
@@ -2,26 +2,26 @@
 #
 # CCM Configuration file
 #
-# $host gets substitued with the hostname and
-# $domain gets substitued with the domain
+# __HOST__ gets substitued with the hostname and
+# __DOMAIN__ gets substitued with the domain
 #
 #############################################################
 
 # profile's URL (primary URL)
 # you can use either HTTP or HTTPS protocols
 #
-profile		http://host.mydomain.org/profiles/$host.xml
+profile		http://host.mydomain.org/profiles/__HOST__.xml
 
 # failover URL (secondary URL)
 # in case the above URL is not reachable after
 # $retrieve_retries times, then try to access a failover URL
 
-#profile_failover	http://hostfailover.mydomain.org/profiles/$host.xml
+#profile_failover	http://hostfailover.mydomain.org/profiles/__HOST__.xml
 
 
 # context URL
 #
-# context		http://host.mydomain.org/$host.$domain.ctx
+# context		http://host.mydomain.org/__HOST__.__DOMAIN__.ctx
 
 # turn on debugging (1/0)
 #

--- a/src/main/perl/CCfg.pm
+++ b/src/main/perl/CCfg.pm
@@ -227,25 +227,35 @@ my $cfg = {%DEFAULT_CFG};
 # even when re-reading the config file
 my $force_cfg = {};
 
+
+# We allow magic variable/keyword expansion in the config file
+#   __HOST__ (deprecated: $host): replaced by hostname() value
+#   __DOMAIN__ (deprecated: $domain): replaced by hostdomain() value
+# (The $host and $domain is deprecated as it can interfere with
+# CAF::Application / Appconfig variable expansion)
 sub _resolveTags ($)
 {
     my ($s) = @_;
-    if ($s =~ /\$host/) {
+    my $host_pattern = '(__HOST__|\$host)';
+    if ($s =~ /$host_pattern/) {
         my $h = hostname();
         unless ($h) {
             throw_error("could not resolve the hostname!");
             return ();
         }
         $h = lc($h);    # use lowercase for host.
-        $s =~ s/\$host/$h/g;
+        $s =~ s/$host_pattern/$h/g;
     }
-    if ($s =~ /\$domain/) {
+
+
+    my $domain_pattern = '(__DOMAIN__|\$domain)';
+    if ($s =~ /$domain_pattern/) {
         my $d = hostdomain();
         unless ($d) {
             throw_error("could not resolve the domainname!");
             return ();
         }
-        $s =~ s/\$domain/$d/g;
+        $s =~ s/$domain_pattern/$d/g;
     }
     return $s;
 }

--- a/src/test/perl/test-ccfg.t
+++ b/src/test/perl/test-ccfg.t
@@ -28,6 +28,25 @@ my $ec = LC::Exception::Context->new->will_store_errors;
 
 # test the resolveTags  method
 is(EDG::WP4::CCM::CCfg::_resolveTags("a"),       "a",     "_resolveTags(a)");
+
+is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST__'),   $host,   '_resolveTags(__HOST__)');
+is(EDG::WP4::CCM::CCfg::_resolveTags('__DOMAIN__'), $domain, '_resolveTags(__DOMAIN__)');
+is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST____DOMAIN__'), $host . $domain,
+    '_resolveTags(__HOST____DOMAIN__)');
+is(
+    EDG::WP4::CCM::CCfg::_resolveTags('__HOST__host__DOMAIN__domain'),
+    $host . "host" . $domain . "domain",
+    '_resolveTags(__HOST__host__DOMAIN__domain)'
+);
+is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST____DOMAIN____HOST____DOMAIN__'),
+    "$host$domain$host$domain", '_resolveTags(__HOST____DOMAIN____HOST____DOMAIN__)');
+is(
+    EDG::WP4::CCM::CCfg::_resolveTags(':__HOST__/__DOMAIN__/__HOST__/__DOMAIN__'),
+    ":$host/$domain/$host/$domain",
+    '_resolveTags(:__HOST__/__DOMAIN__/__HOST__/__DOMAIN__)'
+);
+
+# deprecated $host / $domain
 is(EDG::WP4::CCM::CCfg::_resolveTags('$host'),   $host,   '_resolveTags($host)');
 is(EDG::WP4::CCM::CCfg::_resolveTags('$domain'), $domain, '_resolveTags($domain)');
 is(EDG::WP4::CCM::CCfg::_resolveTags('$host$domain'), $host . $domain,

--- a/src/test/perl/test-ccfg.t
+++ b/src/test/perl/test-ccfg.t
@@ -27,42 +27,41 @@ my $ccfgconfig = getcwd() . "/src/main/conf/ccm.conf";
 my $ec = LC::Exception::Context->new->will_store_errors;
 
 # test the resolveTags  method
-is(EDG::WP4::CCM::CCfg::_resolveTags("a"),       "a",     "_resolveTags(a)");
+is(EDG::WP4::CCM::CCfg::_resolveTags("a"), "a",
+   "_resolveTags(a) returned (unexpanded) a");
 
-is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST__'),   $host,   '_resolveTags(__HOST__)');
-is(EDG::WP4::CCM::CCfg::_resolveTags('__DOMAIN__'), $domain, '_resolveTags(__DOMAIN__)');
+is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST__'), $host,
+   '_resolveTags(__HOST__) correctly expanded __HOST__');
+is(EDG::WP4::CCM::CCfg::_resolveTags('__DOMAIN__'), $domain,
+   '_resolveTags(__DOMAIN__) correctly expanded __DOMAIN__');
 is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST____DOMAIN__'), $host . $domain,
-    '_resolveTags(__HOST____DOMAIN__)');
-is(
-    EDG::WP4::CCM::CCfg::_resolveTags('__HOST__host__DOMAIN__domain'),
-    $host . "host" . $domain . "domain",
-    '_resolveTags(__HOST__host__DOMAIN__domain)'
-);
+    '_resolveTags(__HOST____DOMAIN__) correctly expanded __HOST__ followed by __DOMAIN__');
+is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST__host__DOMAIN__domain'),
+   $host . "host" . $domain . "domain",
+   '_resolveTags(__HOST__host__DOMAIN__domain) correctly expanded __HOST__ followed by __DOMAIN__ with some letters in between');
 is(EDG::WP4::CCM::CCfg::_resolveTags('__HOST____DOMAIN____HOST____DOMAIN__'),
-    "$host$domain$host$domain", '_resolveTags(__HOST____DOMAIN____HOST____DOMAIN__)');
-is(
-    EDG::WP4::CCM::CCfg::_resolveTags(':__HOST__/__DOMAIN__/__HOST__/__DOMAIN__'),
-    ":$host/$domain/$host/$domain",
-    '_resolveTags(:__HOST__/__DOMAIN__/__HOST__/__DOMAIN__)'
-);
+    "$host$domain$host$domain",
+   '_resolveTags(__HOST____DOMAIN____HOST____DOMAIN__) correctly expanded __HOST__ followed by __DOMAIN__ followed by __HOST__ followed by __DOMAIN__');
+
+is(EDG::WP4::CCM::CCfg::_resolveTags(':__HOST__/__DOMAIN__/__HOST__/__DOMAIN__'),
+   ":$host/$domain/$host/$domain",
+   '_resolveTags(:__HOST__/__DOMAIN__/__HOST__/__DOMAIN__) correctly expanded __HOST__ followed by __DOMAIN__ followed by __HOST__ followed by __DOMAIN__ separated by /');
 
 # deprecated $host / $domain
-is(EDG::WP4::CCM::CCfg::_resolveTags('$host'),   $host,   '_resolveTags($host)');
-is(EDG::WP4::CCM::CCfg::_resolveTags('$domain'), $domain, '_resolveTags($domain)');
+is(EDG::WP4::CCM::CCfg::_resolveTags('$host'), $host,
+   '_resolveTags($host) correctly expanded $host');
+is(EDG::WP4::CCM::CCfg::_resolveTags('$domain'), $domain,
+   '_resolveTags($domain) correctly expanded $domain');
 is(EDG::WP4::CCM::CCfg::_resolveTags('$host$domain'), $host . $domain,
-    '_resolveTags($host$domain)');
-is(
-    EDG::WP4::CCM::CCfg::_resolveTags('$hosthost$domaindomain'),
-    $host . "host" . $domain . "domain",
-    '_resolveTags($hosthost$domaindomain)'
-);
+    '_resolveTags($host$domain) correctly expanded $host forllowed by $domain');
+is(EDG::WP4::CCM::CCfg::_resolveTags('$hosthost$domaindomain'),
+   $host . "host" . $domain . "domain",
+   '_resolveTags($hosthost$domaindomain) correctly expanded $host followed by $domain with some letters in between');
 is(EDG::WP4::CCM::CCfg::_resolveTags('$host$domain$host$domain'),
-    "$host$domain$host$domain", '_resolveTags($host$domain$host$domain)');
-is(
-    EDG::WP4::CCM::CCfg::_resolveTags(':$host/$domain/$host/$domain'),
-    ":$host/$domain/$host/$domain",
-    '_resolveTags(:$host/$domain/$host/$domain)'
-);
+    "$host$domain$host$domain", '_resolveTags($host$domain$host$domain) correctly expanded $host followed by $domain followed by $host followed by $domain');
+is(EDG::WP4::CCM::CCfg::_resolveTags(':$host/$domain/$host/$domain'),
+   ":$host/$domain/$host/$domain",
+   '_resolveTags(:$host/$domain/$host/$domain) correctly expanded $host followed by $domain followed by $host followed by $domain separated by /');
 
 
 # unittest to check empty/non-existing/invalid keyword


### PR DESCRIPTION
($host and $domain can be used for Appconfig's variable expansion, but they are invalid ccm.conf parameters)

Fixes #71