### PR TITLE
Remove exec-maven-plugin version definition (done in master pom file)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
         <executions>
           <execution>
             <id>ccm-fetch-man</id>


### PR DESCRIPTION
No reason to define explicitly a version in component pom.xml except very specific needs... Done in main pom.xml.