### PR TITLE
Fix purge_time config parameter in ccm-purge.

### DIFF
--- a/src/main/bin/ccm-purge
+++ b/src/main/bin/ccm-purge
@@ -107,7 +107,6 @@ sub init
     my $usage = "$0 [--time seconds] [--conf ccm.conf] [--tolerant]";
 
     $ccm_conf = "";
-    $TimeAging = EDG::WP4::CCM::CCfg::getCfgValue("purge_time");
     $Tolerant  = 0;
     my $help = 0;
     GetOptions('config=s'  => \$ccm_conf,
@@ -116,13 +115,14 @@ sub init
                'help'      => \$help,
         ) or die("error processing command line: $!\n $usage");
 
-    die("Usage: $usage\n") if ($help || !$TimeAging);
-
     if (!$ccm_conf) {
         initCfg();
     } else {
         initCfg($ccm_conf);
     }
+
+    $TimeAging = EDG::WP4::CCM::CCfg::getCfgValue("purge_time") if (!defined($TimeAging));
+    die("Usage: $usage\n") if ($help);
 
     $CacheDir = EDG::WP4::CCM::CCfg::getCfgValue("cache_root");
     my $numKeep = EDG::WP4::CCM::CCfg::getCfgValue("keep_old");


### PR DESCRIPTION
It is read before the config is initialised, so always gets the default
value of 1 day. Move things round a bit so this is configurable (with
the command line argument taking precedence over the config).