### PR TITLE
Path: support escape path and safe_unescape

### DIFF
--- a/src/main/conf/quattor-ccm
+++ b/src/main/conf/quattor-ccm
@@ -59,7 +59,11 @@ _quattor_ccm_pan_path()
     pref=$2
     # default is start from /
     # require at least one extra character in completion
-    $_quattor_grep_path -e "^${pref:-/}\(/\|[^/]\+/\?\)\$" $_quattor_ccm_cache_root/profile.$cid/tabcompletion 2>/dev/null | $_quattor_sed_path ':a;N;$!ba;s/\n/ /g;'
+    # patterns
+    #   only trailing /
+    #   non-/ with optional trailing /
+    #   single (pan) subpath enclosed in {} with optinal trailing /
+    $_quattor_grep_path -e "^${pref:-/}\(/\|\([^/}]\+\|\(\{\)\?[^{}]\+\?\}\)/\?\)\$" $_quattor_ccm_cache_root/profile.$cid/tabcompletion 2>/dev/null | $_quattor_sed_path ':a;N;$!ba;s/\n/ /g;'
 }
 
 _quattor_ccm_tabcomp_cids()

--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -45,7 +45,7 @@ sub _initialize {
     # Final arguments are all profpaths
     if (@$argsref) {
         $self->{profpaths} = $argsref;
-        $self->debug(2, "Add non-option cmdline profpaths: ", join(',', $self->{profpaths}));
+        $self->debug(2, "Add non-option cmdline profpaths: ", join(',', @{$self->{profpaths}}));
     } else {
         $self->{profpaths} = [];
         $self->debug(2, "No non-option cmdline profpaths");

--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -9,8 +9,9 @@ use strict;
 use warnings;
 
 use base qw(EDG::WP4::CCM::Options);
-use LC::Exception qw(SUCCESS);
+use CAF::Object qw(SUCCESS);
 use EDG::WP4::CCM::TextRender qw(ccm_format @CCM_FORMATS);
+use EDG::WP4::CCM::Path qw(set_safe_unescape reset_safe_unescape);
 use Readonly;
 
 Readonly::Hash my %CLI_ACTIONS => {
@@ -89,6 +90,8 @@ sub action_show
     my $cfg = $self->getCCMConfig();
     return if (! defined($cfg));
 
+    set_safe_unescape();
+
     foreach my $path (@{$self->gatherPaths(@{$self->{profpaths}})}) {
         if(! $cfg->elementExists($path)) {
             $self->debug(4, "action_show: no element for path $path");
@@ -116,6 +119,8 @@ sub action_show
             return;
         };
     }
+
+    reset_safe_unescape();
 
     return SUCCESS;
 }

--- a/src/main/perl/Element.pm
+++ b/src/main/perl/Element.pm
@@ -13,7 +13,7 @@ use File::Spec;
 use Encode qw(decode_utf8);
 use LC::Exception qw(SUCCESS throw_error);
 use EDG::WP4::CCM::Configuration;
-use EDG::WP4::CCM::Path;
+use EDG::WP4::CCM::Path qw(escape unescape);
 use EDG::WP4::CCM::Property;
 use EDG::WP4::CCM::Resource;
 use Exporter;
@@ -86,39 +86,7 @@ Type constants:
 
 =over
 
-
 =cut
-
-=item unescape($string)
-
-Returns an unescaped version of the string. This method is exported
-for use with all the components that deal with escaped keys.
-
-=cut
-
-sub unescape
-{
-    my $str = shift;
-    $str =~ s!(_[0-9a-f]{2})!sprintf ("%c", hex($1))!eg;
-    return $str;
-}
-
-=pod
-
-=item escape($string)
-
-Returns an escaped version of the string.  This method is exported on
-demand for use with all tools that have to escape and unescape values.
-
-=cut
-
-sub escape
-{
-    my $str = shift;
-
-    $str =~ s/(^[0-9]|[^a-zA-Z0-9])/sprintf("_%lx", ord($1))/eg;
-    return $str;
-}
 
 =item new($config, $ele_path)
 

--- a/src/main/perl/Element.pm
+++ b/src/main/perl/Element.pm
@@ -137,7 +137,6 @@ sub new
 
     if (UNIVERSAL::isa($ele_path, "EDG::WP4::CCM::Path")) {
         $self->{PATH} = $ele_path;
-        $ele_path = $ele_path->toString();
     } else {
         $self->{PATH} = EDG::WP4::CCM::Path->new($ele_path);
         if (!$self->{PATH}) {
@@ -146,16 +145,24 @@ sub new
         }
     }
 
-    $self->{NAME} = $self->{PATH}->toString();
-    $self->{NAME} =~ /.*\/(.*)/;
-    $self->{NAME} = $1;
+    # LAST is last element (can be undef if this is root element)
+    # get_last is Path::_safe_unescaped,
+    # LAST is used by getTree, so it should still be possible to
+    # use the getTree key to build a subpath,
+    # even if is ugly/redundant as name of a subpath
+    # (but use NAME for "pretty" last subpath)
+    # so safe_unescape should generate the leading/trailing {}
+    $self->{LAST} = $self->{PATH}->get_last();
 
-    # the name of the element wiht Path("/") is "/"
-    if ($self->{NAME} eq "") {
-        $self->{NAME} = "/";
-    }
+    # NAME is last element or '/'
+    # get_last is Path::_safe_unescaped,
+    # so NAME can vary if Path's @safe_unescape is non-empty
+    # This is a "pretty" name,
+    # so safe_unescape should not generate the leading/trailing {}
+    $self->{NAME} = $self->{PATH}->depth(1) ? $self->{PATH}->get_last() : '/';
 
-    $self->{EID} = _resolve_eid($prof_dir, $ele_path);
+    $self->{EID} = _resolve_eid($prof_dir, $self->{PATH}->toString());
+
     if (!defined($self->{EID})) {
         throw_error("failed to resolve element's ID", $ec->error);
         return ();
@@ -234,9 +241,11 @@ sub elementExists
     $config   = shift;    # profile's directory path
     $ele_path = shift;    # element's configuration path
 
-    if (UNIVERSAL::isa($ele_path, "EDG::WP4::CCM::Path")) {
-        $ele_path = $ele_path->toString();
+    if (! UNIVERSAL::isa($ele_path, "EDG::WP4::CCM::Path")) {
+        $ele_path = EDG::WP4::CCM::Path->new("$ele_path");
     }
+    $ele_path = $ele_path->toString();
+
     $prof_dir = $config->getConfigPath();
     my ($hashref, $eid);
 
@@ -276,9 +285,10 @@ sub createElement
     $config   = shift;    # profile's directory path
     $ele_path = shift;    # element's configuration path
 
-    if (UNIVERSAL::isa($ele_path, "EDG::WP4::CCM::Path")) {
-        $ele_path = $ele_path->toString();
+    if (! UNIVERSAL::isa($ele_path, "EDG::WP4::CCM::Path")) {
+        $ele_path = EDG::WP4::CCM::Path->new("$ele_path");
     }
+    $ele_path = $ele_path->toString();
 
     $ele_type = _read_type($config, $ele_path);
     if (!$ele_type) {
@@ -587,7 +597,10 @@ SWITCH:
             $ret = {};
             while ($self->hasNextElement) {
                 $el = $self->getNextElement();
-                $$ret{$el->getName()} = $el->getTree($nextdepth, %opts);
+                # we can use LAST here, as only the root element returns an undef
+                # and this cannot be the root element
+                # we have to use LAST here, as we want the key to be a valid subpath
+                $$ret{$el->{LAST}} = $el->getTree($nextdepth, %opts);
             }
             $convm = $opts{convert_nlist};
             last SWITCH;

--- a/src/main/perl/Fetch/ProfileCache.pm
+++ b/src/main/perl/Fetch/ProfileCache.pm
@@ -29,6 +29,7 @@ use EDG::WP4::CCM::CacheManager qw($GLOBAL_LOCK_FN
     $CURRENT_CID_FN $LATEST_CID_FN
     $DATA_DN $PROFILE_DIR_N);
 use EDG::WP4::CCM::TextRender qw(ccm_format);
+use EDG::WP4::CCM::Path qw(set_safe_unescape reset_safe_unescape);
 
 use CAF::FileWriter;
 use CAF::FileReader;
@@ -311,6 +312,8 @@ sub generate_tabcompletion
     my $cmgr = EDG::WP4::CCM::CacheManager->new($self->{CACHE_ROOT}, $self->{_CCFG});
     my $cfg = $cmgr->getLockedConfiguration(undef, $cid);
     my $el = $cfg->getElement('/');
+
+    set_safe_unescape();
     my $fmt = ccm_format('tabcompletion', $el);
 
     if (defined $fmt->get_text()) {
@@ -319,7 +322,8 @@ sub generate_tabcompletion
     } else {
         $self->error("Failed to render tabcompletion: $fmt->{fail}")
     }
-
+    # Reset after all stringification is done
+    reset_safe_unescape();
 }
 
 # Stores a persistent cache in the directories defined by %cur, from a

--- a/src/main/perl/Options.pm
+++ b/src/main/perl/Options.pm
@@ -12,7 +12,8 @@ use CAF::Application qw($OPTION_CFGFILE);
 use CAF::Reporter;
 use LC::Exception qw(SUCCESS);
 use EDG::WP4::CCM::CCfg qw(@CONFIG_OPTIONS $CONFIG_FN setCfgValue);
-use EDG::WP4::CCM::Element qw(escape);
+use EDG::WP4::CCM::Path qw(escape);
+use EDG::WP4::CCM::CacheManager;
 use Readonly;
 
 our @ISA = qw(CAF::Application CAF::Reporter);

--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -1,19 +1,8 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-
-package      EDG::WP4::CCM::Path;
-
-use strict;
-use warnings;
+#${PMpre} EDG::WP4::CCM::Path${PMpost}
 
 use LC::Exception qw(SUCCESS throw_error);
-use parent qw(Exporter);
 
-our @EXPORT    = qw();
-our @EXPORT_OK = qw();
-our $VERSION   = '${project.version}';
+our $ec = LC::Exception::Context->new->will_store_errors;
 
 use overload '""' => 'toString';
 
@@ -23,10 +12,12 @@ EDG::WP4::CCM::Path - Path class
 
 =head1 SYNOPSIS
 
- $path = Path->new(["/hardware/memory/size"]);
- $string = $path->toString();
- $path = $path->down($string);
- $path = $path->up();
+    $path = EDG::WP4::CCM::Path->new("/hardware/memory/size");
+    print "$path"; # stringification
+
+    $path = $path->down($level);
+
+    $path = $path->up();
 
 =head1 DESCRIPTION
 
@@ -35,18 +26,15 @@ to manipulate absolute paths
 
 =over
 
-=cut
-
-our $ec = LC::Exception::Context->new->will_store_errors;
-
 =item new ($path)
 
-create new object of Path type. Empty string is not
-allowed as an input parameter. If input parameter is not specified,
-Path is initialized to the root path ("/").
+Create new C<EDG::WP4::CCM::Path> instance.
 
-$path is a string representation of the path as defined in the NVA-API
-Specification document
+If C<path> argument is not specified, root path (C</>) is used.
+Empty string is not allowed as an argument.
+
+C<path> is a string representation of the path as defined in the NVA-API
+Specification document.
 
 =cut
 
@@ -67,9 +55,9 @@ sub new
     # must start with /, but not with //+
     unless (defined($start) && $start eq '' && (!@s || $s[0] ne '')) {
         throw_error("path $path must be an absolute path: start '"
-                . ($start || '')
-                . "', remainder "
-                . join(' / ', @s));
+                    . ($start || '')
+                    . "', remainder "
+                    . join(' / ', @s));
         return ();
     }
 
@@ -78,9 +66,11 @@ sub new
     return $self;
 }
 
-=item toString ()
+=item toString
 
-get the string representation of path
+Get the string representation of path. The C<EDG::WP4::CCM::Path>
+instances also support stringification (this C<toString> also is used
+for that).
 
 =cut
 
@@ -90,11 +80,11 @@ sub toString
     return "/" . join('/', @$self);
 }
 
-=item up ()
+=item up
 
-removes last chunk of the path and returns it.
-if the path is already "/" then then methods
-rises an exception
+Removes last chunk of the path and returns it.
+If the path is already C</> then the method
+raises an exception.
 
 =cut
 
@@ -110,8 +100,8 @@ sub up
 
 =item down ($chunk)
 
-add one chunk to a path, chunk cannot be compound path
-(it cannot contain "/" or be empty)
+Add one chunk to the path. The chunk cannot be compound path
+(it cannot contain "/" or be empty).
 
 =cut
 
@@ -126,9 +116,9 @@ sub down
     return $self;
 }
 
-=item merge (@subpaths)
+=item merge
 
-Return a new instance with optional subpaths added
+Return a new instance with optional (list of) subpaths added.
 
 =cut
 

--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -1,5 +1,9 @@
 #${PMpre} EDG::WP4::CCM::Path${PMpost}
 
+use parent qw(Exporter);
+our @EXPORT    = qw(unescape);
+our @EXPORT_OK = qw(escape);
+
 use LC::Exception qw(SUCCESS throw_error);
 
 our $ec = LC::Exception::Context->new->will_store_errors;
@@ -23,6 +27,8 @@ EDG::WP4::CCM::Path - Path class
 
 Module provides implementation of the Path class. Class is used
 to manipulate absolute paths
+
+=head2 Public methods
 
 =over
 
@@ -133,6 +139,41 @@ sub merge
         $newpath->down($subpath);
     }
     return $newpath
+}
+
+=back
+
+=head2 Public functions
+
+=over
+
+=item unescape
+
+Returns an unescaped version of the argument. This method is exported
+for use with all the components that deal with escaped keys.
+
+=cut
+
+sub unescape
+{
+    my $str = shift;
+    $str =~ s!(_[0-9a-f]{2})!sprintf ("%c", hex($1))!eg;
+    return $str;
+}
+
+=item escape
+
+Returns an escaped version of the argument.  This method is exported on
+demand for use with all tools that have to escape and unescape values.
+
+=cut
+
+sub escape
+{
+    my $str = shift;
+
+    $str =~ s/(^[0-9]|[^a-zA-Z0-9])/sprintf("_%lx", ord($1))/eg;
+    return $str;
 }
 
 

--- a/src/main/perl/Resource.pm
+++ b/src/main/perl/Resource.pm
@@ -224,6 +224,7 @@ sub getCurrentElement
     } else {
         $el_path = $path . "/" . $self->{ELEMENTS}[$self->{CURRENT}];
     }
+
     $element = EDG::WP4::CCM::Element->createElement($self->{CONFIG}, $el_path);
     unless ($element) {
         throw_error("failed to create element $el_path", $ec->error);

--- a/src/main/perl/TextRender.pm
+++ b/src/main/perl/TextRender.pm
@@ -10,7 +10,7 @@ use warnings;
 use CAF::TextRender qw($YAML_BOOL_PREFIX);
 use Readonly;
 use EDG::WP4::CCM::TT::Scalar qw(%ELEMENT_TYPES);
-use EDG::WP4::CCM::Element qw(escape unescape);
+use EDG::WP4::CCM::Path qw(escape unescape);
 use XML::Parser;
 use base qw(CAF::TextRender Exporter);
 

--- a/src/main/resources/pancxml_element.tt
+++ b/src/main/resources/pancxml_element.tt
@@ -8,7 +8,7 @@
 -%]
 <[%- pantype -%][%- format ? ' format="' _  format _ '"' : '' -%][%- name ? ' name="' _  name _ '"' : '' -%]>
 [%- IF CCM.is_scalar(data) -%]
-[%- data -%]
+[%-     data -%]
 [%- ELSIF CCM.is_list(data) %]
 [%     FOREACH value IN data -%]
 [%-          INCLUDE CCM/pancxml_element.tt data=value name='' format='' FILTER indent -%]

--- a/src/main/resources/query_resource.tt
+++ b/src/main/resources/query_resource.tt
@@ -1,4 +1,4 @@
 [%-# 2 space indendatation * depth, +- and element name
     space = ' '
     offset = path.size - CCM.element.path.size -%]
-[% space.repeat(2 * offset) %]+-[% CCM.unescape(offset ? path.last : path) %]
+[% space.repeat(2 * offset) %]+-[% offset ? path.get_last : path %]

--- a/src/main/resources/query_scalar.tt
+++ b/src/main/resources/query_scalar.tt
@@ -1,5 +1,5 @@
 [%-# 2 space indentation * depth, $, type, element name, single quoted value
     space = ' ';
     offset = path.size - CCM.element.path.size -%]
-[%-# scalar path is not unescaped -%] 
-[% space.repeat(2 * offset) %]$ [% path.last -%] : [% data %]
+[%-# scalar path is not unescaped -%]
+[% space.repeat(2 * offset) %]$ [% path.get_last -%] : [% data %]

--- a/src/main/resources/tests/profiles/basic.pan
+++ b/src/main/resources/tests/profiles/basic.pan
@@ -7,6 +7,7 @@ unique template basic;
 
 "/special/not_escaped_d/not_escaped_d" = "not_escaped_d";
 "/special/{escaped data}/{escaped data}" = "escaped data";
+"/special/safe_unescape/{/a/b/c}" = "safe unescape";
 
 # Some larger, deeper example
 "/z/deep/a" = "a";
@@ -19,4 +20,3 @@ unique template basic;
     "etest", "ok",
 );
 "/z/deep/list/2/fake" = 1;
-

--- a/src/main/resources/tests/regexps/ncmquery/base
+++ b/src/main/resources/tests/regexps/ncmquery/base
@@ -20,6 +20,8 @@ element=truefalse
 ^\s{6}\$ escaped_20data : \(string\) 'escaped data'$
 ^\s{4}\+-not_escaped_d$
 ^\s{6}\$ not_escaped_d : \(string\) 'not_escaped_d'$
+^\s{4}\+-safe_unescape$
+^\s{6}\$ _2fa_2fb_2fc : \(string\) 'safe unescape'$
 ^\s{2}\+-z$
 ^\s{4}\+-deep$
 ^\s{6}\$ a : \(string\) 'a'$

--- a/src/main/resources/tests/regexps/ncmquery/whitespace
+++ b/src/main/resources/tests/regexps/ncmquery/whitespace
@@ -9,5 +9,5 @@ element=truefalse
 unordered
 ---
 \n\z
-\n ### COUNT 29
-$ ### COUNT 30
+\n ### COUNT 31
+$ ### COUNT 32

--- a/src/main/resources/tests/regexps/pan/base
+++ b/src/main/resources/tests/regexps/pan/base
@@ -13,6 +13,7 @@ element=truefalse,doublequote
 ^"/data/oneandahalf" = 1.5; # double$
 ^"/special/escaped_20data/escaped_20data" = "escaped data"; # string$
 ^"/special/not_escaped_d/not_escaped_d" = "not_escaped_d"; # string$
+^"/special/safe_unescape/\{/a/b/c\}" = "safe unescape"; # string$
 ^"/z/deep/a" = "a"; # string$
 ^"/z/deep/list/0/a/b" = "a"; # string$
 ^"/z/deep/list/1/atest" = 1; # long$

--- a/src/main/resources/tests/regexps/pan/whitespace
+++ b/src/main/resources/tests/regexps/pan/whitespace
@@ -9,5 +9,5 @@ element=truefalse,doublequote
 unordered
 ---
 \n\z
-\n ### COUNT 15
-$ ### COUNT 16
+\n ### COUNT 16
+$ ### COUNT 17

--- a/src/main/resources/tests/regexps/pancxml/base
+++ b/src/main/resources/tests/regexps/pancxml/base
@@ -27,6 +27,9 @@ element=truefalse,xml
 ^        <nlist name="not_escaped_d">$
 ^            <string name="not_escaped_d">not_escaped_d</string>$
 ^        </nlist>$
+^        <nlist name="safe_unescape">$
+^            <string name="\{/a/b/c\}">safe unescape</string>$
+^        </nlist>$
 ^    </nlist>$
 ^    <nlist name="z">$
 ^        <nlist name="deep">$
@@ -51,4 +54,3 @@ element=truefalse,xml
 ^        </nlist>$
 ^    </nlist>$
 ^</nlist>$
-

--- a/src/main/resources/tests/regexps/pancxml/whitespace
+++ b/src/main/resources/tests/regexps/pancxml/whitespace
@@ -9,5 +9,5 @@ element=truefalse,xml
 unordered
 ---
 \n\z
-\n ### COUNT 44
-$ ### COUNT 45
+\n ### COUNT 47
+$ ### COUNT 48

--- a/src/main/resources/tests/regexps/query/base
+++ b/src/main/resources/tests/regexps/query/base
@@ -16,10 +16,12 @@ element=truefalse,singlequote
 ^\s{4}\$ one : 1$
 ^\s{4}\$ oneandahalf : 1.5$
 ^\s{2}\+-special$
-^\s{4}\+-escaped data$
+^\s{4}\+-escaped_20data$
 ^\s{6}\$ escaped_20data : 'escaped data'$
 ^\s{4}\+-not_escaped_d$
 ^\s{6}\$ not_escaped_d : 'not_escaped_d'$
+^\s{4}\+-safe_unescape$
+^\s{6}\$ \{/a/b/c\} : 'safe unescape'$
 ^\s{2}\+-z$
 ^\s{4}\+-deep$
 ^\s{6}\$ a : 'a'$

--- a/src/main/resources/tests/regexps/query/whitespace
+++ b/src/main/resources/tests/regexps/query/whitespace
@@ -9,5 +9,5 @@ element=truefalse,singlequote
 unordered
 ---
 \n\z
-\n ### COUNT 29
-$ ### COUNT 30
+\n ### COUNT 31
+$ ### COUNT 32

--- a/src/main/resources/tests/regexps/tabcompletion/base
+++ b/src/main/resources/tests/regexps/tabcompletion/base
@@ -19,6 +19,8 @@ contentspath=/
 ^/special/escaped_20data/escaped_20data$
 ^/special/not_escaped_d/$
 ^/special/not_escaped_d/not_escaped_d$
+^/special/safe_unescape/$
+^/special/safe_unescape/\{/a/b/c\}$
 ^/z/$
 ^/z/deep/$
 ^/z/deep/a$

--- a/src/main/resources/tests/regexps/tabcompletion/whitespace
+++ b/src/main/resources/tests/regexps/tabcompletion/whitespace
@@ -8,5 +8,5 @@ contentspath=/
 unordered
 ---
 \n\z
-\n ### COUNT 29
-$ ### COUNT 30
+\n ### COUNT 31
+$ ### COUNT 32

--- a/src/test/perl/01_tt.t
+++ b/src/test/perl/01_tt.t
@@ -3,8 +3,12 @@ use warnings;
 use Test::More;
 use Test::Quattor::ProfileCache qw(set_json_typed);
 use Test::Quattor::TextRender::Component;
+use EDG::WP4::CCM::Path qw(set_safe_unescape);
 
 set_json_typed();
+
+set_safe_unescape('/special/safe_unescape');
+$EDG::WP4::CCM::Path::_safe_unescape_restore = ['/special/safe_unescape'];
 
 my $t = Test::Quattor::TextRender::Component->new(
     component => 'CCM',

--- a/src/test/perl/CCMTest.pm
+++ b/src/test/perl/CCMTest.pm
@@ -32,7 +32,7 @@ sub eok ($$$) {
       $cec->ignore_error();
       return SUCCESS;
     }
-  } 
+  }
   ok (0, "exception: $descr");
 }
 

--- a/src/test/perl/escaping.t
+++ b/src/test/perl/escaping.t
@@ -1,8 +1,9 @@
-#!/usr/bin/perl -w
 use strict;
 use warnings;
+
 use Test::More;
 
+# Old API, actual code in Path
 use EDG::WP4::CCM::Element qw(escape unescape);
 
 =pod

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -10,15 +10,19 @@ use warnings;
 use Test::More;
 use CCMTest qw (eok);
 use LC::Exception qw(SUCCESS);
-use EDG::WP4::CCM::Path qw ();
+use EDG::WP4::CCM::Path qw (escape unescape);
 
 my $ec = LC::Exception::Context->new->will_store_errors;
 
-eok($ec, EDG::WP4::CCM::Path->new("///a/b/c"), 
+=head2 new
+
+=cut
+
+eok($ec, EDG::WP4::CCM::Path->new("///a/b/c"),
     'EDG::WP4::CCM::Path->new("///a/b/c")');
-eok($ec, EDG::WP4::CCM::Path->new("//a/b/c"), 
+eok($ec, EDG::WP4::CCM::Path->new("//a/b/c"),
     'EDG::WP4::CCM::Path->new("//a/b/c")');
-eok($ec, EDG::WP4::CCM::Path->new("a/b/c"), 
+eok($ec, EDG::WP4::CCM::Path->new("a/b/c"),
     'EDG::WP4::CCM::Path->new("a/b/c")');
 eok ($ec, EDG::WP4::CCM::Path->new(""),
     'EDG::WP4::CCM::Path->new("")');
@@ -50,9 +54,18 @@ my @paths = @$path;
 # so stringification kicks in, and this doesn't match anymore
 is_deeply(\@paths, ['a', 'b', 'c'], "Correct array reference");
 
+=head2 toString / stringification
+
+=cut
+
 ok ($path = EDG::WP4::CCM::Path->new("/a/b/c/"),
     'EDG::WP4::CCM::Path->new("/a/b/c/")');
 is ($path->toString(), "/a/b/c", "$path->toString()");
+is("$path", "/a/b/c", "path stringification");
+
+=head2 up / down
+
+=cut
 
 ok ($path->up() && ($path->toString() eq "/a/b"), "$path->up()");
 ok ($path->up() && ($path->toString() eq "/a"), "$path->up()");
@@ -61,6 +74,10 @@ ok ($path->up() && ($path->toString() eq "/"), "$path->up()");
 ok ($path->down("b") && ($path->toString() eq "/b"), '$path->down("b")');
 eok ($ec, $path->down("/b"), '$path->down("/b")');
 eok ($ec, $path->down(""), '$path->down("")');
+
+=head2 merge
+
+=cut
 
 $path = EDG::WP4::CCM::Path->new("/a/b/c");
 isa_ok($path, "EDG::WP4::CCM::Path", "new returns EDG::WP4::CCM::Path instance");
@@ -72,5 +89,19 @@ is("$newpath", "$path", "Stringification ok");
 $newpath = $path->merge("d", "e", "f");
 isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance");
 is("$newpath", "$path/d/e/f", "Stringification ok");
+
+=head2 escape / unescape
+
+=cut
+
+is(unescape(escape("kernel-2.6.32")), "kernel-2.6.32",
+   "Escaping and unescaping cancel each other out");
+
+is(escape("kernel-2.6.32"), "kernel_2d2_2e6_2e32",
+   "Escaping works as expected");
+is(unescape("kernel_2d2_2e6_2e32"), "kernel-2.6.32",
+   "Unescaping works as expected");
+
+
 
 done_testing();

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -14,6 +14,37 @@ use EDG::WP4::CCM::Path qw (escape unescape);
 
 my $ec = LC::Exception::Context->new->will_store_errors;
 
+=head2 escape / unescape
+
+=cut
+
+is(unescape(escape("kernel-2.6.32")), "kernel-2.6.32",
+   "Escaping and unescaping cancel each other out");
+
+is(escape("kernel-2.6.32"), "kernel_2d2_2e6_2e32",
+   "Escaping works as expected");
+is(unescape("kernel_2d2_2e6_2e32"), "kernel-2.6.32",
+   "Unescaping works as expected");
+
+=head2 path_split
+
+=cut
+
+sub sok {
+    my ($path, $res, $msg, $single) = @_;
+    unshift(@$res, '') if ! $single; # the empty string after split from the leading / or single subpath
+    is_deeply([EDG::WP4::CCM::Path::path_split($path)], $res, $msg);
+};
+
+sok("", [], "Split empty string", 1);
+sok("/a", [qw(a)], "Split single subdir");
+sok("a", [qw(a)], "Split single element string", 1);
+sok("/a/b/c", [qw(a b c)], "Basic split");
+sok("/a/{/x/y/z}/b/c", [qw(a _2fx_2fy_2fz b c)], "Split single escaped path");
+sok("/{/x/y/z}/b/{/sys/fs}/services/{/}", [qw(_2fx_2fy_2fz b _2fsys_2ffs services _2f)], "Split 3 escaped paths");
+sok("{/single/subpath}", [qw(_2fsingle_2fsubpath)], "Split single subpath", 1);
+sok("/{/x/y/z}/{/sys/fs}/{/}", [qw(_2fx_2fy_2fz _2fsys_2ffs _2f)], "Split 3 adjacent escaped paths");
+
 =head2 new
 
 =cut
@@ -75,6 +106,9 @@ ok ($path->down("b") && ($path->toString() eq "/b"), '$path->down("b")');
 eok ($ec, $path->down("/b"), '$path->down("/b")');
 eok ($ec, $path->down(""), '$path->down("")');
 
+ok ($path->down("{/a/b/c}") && ($path->toString() eq "/b/_2fa_2fb_2fc"), '$path->down("{/a/b/c}")');
+
+
 =head2 merge
 
 =cut
@@ -82,26 +116,13 @@ eok ($ec, $path->down(""), '$path->down("")');
 $path = EDG::WP4::CCM::Path->new("/a/b/c");
 isa_ok($path, "EDG::WP4::CCM::Path", "new returns EDG::WP4::CCM::Path instance");
 my $newpath = $path->merge();
-isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance");
+isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance 1");
 is_deeply($newpath, $path, "Merge with empty subpaths returns clone");
-is("$newpath", "$path", "Stringification ok");
+is("$newpath", "$path", "Stringification ok 1");
 
-$newpath = $path->merge("d", "e", "f");
-isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance");
-is("$newpath", "$path/d/e/f", "Stringification ok");
-
-=head2 escape / unescape
-
-=cut
-
-is(unescape(escape("kernel-2.6.32")), "kernel-2.6.32",
-   "Escaping and unescaping cancel each other out");
-
-is(escape("kernel-2.6.32"), "kernel_2d2_2e6_2e32",
-   "Escaping works as expected");
-is(unescape("kernel_2d2_2e6_2e32"), "kernel-2.6.32",
-   "Unescaping works as expected");
-
+$newpath = $path->merge("d", "e", "f", "{/a/b/c}");
+isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance 2");
+is("$newpath", "$path/d/e/f/_2fa_2fb_2fc", "Stringification ok 2");
 
 
 done_testing();

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -14,9 +14,12 @@ use EDG::WP4::CCM::Path qw (escape unescape set_safe_unescape reset_safe_unescap
 
 my $ec = LC::Exception::Context->new->will_store_errors;
 
-is_deeply(\@EDG::WP4::CCM::Path::SAFE_UNESCAPE, [qw(
-    /software/components/metaconfig/services
-)], "List of known safe_unescape");
+is_deeply(\@EDG::WP4::CCM::Path::SAFE_UNESCAPE, [
+    '/software/components/filecopy/services/',
+    '/software/components/metaconfig/services/',
+    '/software/packages/',
+    qr{/software/packages/[^/]+/},
+], "List of known safe_unescape");
 
 =head2 escape / unescape
 
@@ -158,6 +161,19 @@ $newpath = $path->merge("d", "e", "f", "{/a/b/c}");
 isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance 2");
 # the stringifcation of $path shows that $path itself is unmodified
 is("$newpath", "$path/d/e/f/_2fa_2fb_2fc", "Stringification ok 2");
+
+=head2 _test_safe_unescape
+
+=cut
+
+reset_safe_unescape();
+set_safe_unescape(qw(/a/b /a/b/{/a/b/c}/e/f/), qr{^/a/c/[^/]+/});
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/a', '_2fa_2fb_2fc'), '_2fa_2fb_2fc', 'basic _safe_unescape no matching parent');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc'), '{/a/b/c}', 'basic _safe_unescape exact stringmatch');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b/{/a/b/c}/e/f/', '_2fa_2fb_2fc'), '{/a/b/c}', 'basic _safe_unescape exact stringmatch with safe escaped parent');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/c/whatever', '_2fa_2fb_2fc'), '{/a/b/c}', 'basic _safe_unescape with compiled regexp parent');
+
+reset_safe_unescape();
 
 =head2 set_safe_unescape / reset_safe_unescape
 

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -10,9 +10,13 @@ use warnings;
 use Test::More;
 use CCMTest qw (eok);
 use LC::Exception qw(SUCCESS);
-use EDG::WP4::CCM::Path qw (escape unescape);
+use EDG::WP4::CCM::Path qw (escape unescape set_safe_unescape reset_safe_unescape);
 
 my $ec = LC::Exception::Context->new->will_store_errors;
+
+is_deeply(\@EDG::WP4::CCM::Path::SAFE_UNESCAPE, [qw(
+    /software/components/metaconfig/services
+)], "List of known safe_unescape");
 
 =head2 escape / unescape
 
@@ -62,28 +66,34 @@ ok (EDG::WP4::CCM::Path->new("/"),
 
 my $path;
 
-ok ($path = EDG::WP4::CCM::Path->new(),
-    'EDG::WP4::CCM::Path->new()');
-is ($path->toString(), "/", "$path->toString()");
-ok ($path = EDG::WP4::CCM::Path->new("/"),
-    'EDG::WP4::CCM::Path->new("/")');
-is ($path->toString(), "/", "$path->toString()");
-is ("$path", "/", "stringification /");
+sub test_path {
+    my ($patharg, $tostr, $depth, $last, $ref) = @_;
+    my $pathargstr = defined $patharg ? "$patharg" : "<undef>";
+    my $path = EDG::WP4::CCM::Path->new($patharg);
+    isa_ok ($path, 'EDG::WP4::CCM::Path',
+        "EDG::WP4::CCM::Path->new($pathargstr) returns EDG::WP4::CCM::Path instance");
+    is ($path->toString(), $tostr, "path->toString() for $pathargstr");
+    is($path->depth(), $depth, "depth $depth for $pathargstr");
+    my $glast = $path->get_last();
+    if(defined $last) {
+        is($glast, $last, "last $last for $pathargstr");
+    } else {
+        ok(! defined($glast), "last undefined for $pathargstr")
+    }
+    if($ref) {
+        my @paths = @$path;
+        is_deeply(\@paths, $ref, "array reference for $pathargstr");
+    }
+};
 
-ok ($path = EDG::WP4::CCM::Path->new("/a"),
-    'EDG::WP4::CCM::Path->new("/a")');
-is ($path->toString(), "/a", "$path->toString()");
-is ("$path", "/a", "stringification /a");
-
-ok ($path = EDG::WP4::CCM::Path->new("/a/b/c"),
-    'EDG::WP4::CCM::Path->new("/a/b/c")');
-is ($path->toString(), "/a/b/c", "$path->toString()");
-is ("$path", "/a/b/c", "stringification /a/b/c");
-
-my @paths = @$path;
-# is_deeply($path, ...) tries to evaluate $path in string context first?
-# so stringification kicks in, and this doesn't match anymore
-is_deeply(\@paths, ['a', 'b', 'c'], "Correct array reference");
+test_path(undef, '/', 0, undef);
+test_path('/', '/', 0, undef);
+test_path('/a', '/a', 1, 'a');
+test_path('/a/b/c', '/a/b/c', 3, 'c', ['a', 'b', 'c']);
+test_path('/{/x/y/z}/b/{/sys/fs}/services/{/}',
+          '/_2fx_2fy_2fz/b/_2fsys_2ffs/services/_2f',
+          5, '_2f',
+          [qw(_2fx_2fy_2fz b _2fsys_2ffs services _2f)]);
 
 =head2 toString / stringification
 
@@ -94,7 +104,7 @@ ok ($path = EDG::WP4::CCM::Path->new("/a/b/c/"),
 is ($path->toString(), "/a/b/c", "$path->toString()");
 is("$path", "/a/b/c", "path stringification");
 
-=head2 up / down
+=head2 up
 
 =cut
 
@@ -102,12 +112,35 @@ ok ($path->up() && ($path->toString() eq "/a/b"), "$path->up()");
 ok ($path->up() && ($path->toString() eq "/a"), "$path->up()");
 ok ($path->up() && ($path->toString() eq "/"), "$path->up()");
 
-ok ($path->down("b") && ($path->toString() eq "/b"), '$path->down("b")');
-eok ($ec, $path->down("/b"), '$path->down("/b")');
-eok ($ec, $path->down(""), '$path->down("")');
+=head2 down
 
-ok ($path->down("{/a/b/c}") && ($path->toString() eq "/b/_2fa_2fb_2fc"), '$path->down("{/a/b/c}")');
+=cut
 
+ok ($path->down("a") && ($path->toString() eq "/a"), '$path->down("a")');
+# leading / is ignored
+ok ($path->down("/b") && ($path->toString() eq "/a/b"), '$path->down("/b")');
+# noop / ignore '/' path
+ok ($path->down("") && ($path->toString() eq "/a/b"), '$path->down("")');
+# compound path
+ok ($path->down("c/d") && ($path->toString() eq "/a/b/c/d"), '$path->down("c/d")');
+
+ok ($path->down("{/a/b/c}") && ($path->toString() eq "/a/b/c/d/_2fa_2fb_2fc"), '$path->down("{/a/b/c}")');
+
+ok ($path->down("0") && ($path->toString() eq "/a/b/c/d/_2fa_2fb_2fc/0"), '$path->down("0")');
+
+=head2 parent
+
+=cut
+
+$path = EDG::WP4::CCM::Path->new();
+ok(! defined($path->parent()), "root path parent returns undef");
+is("$path", "/", "root path unmodified after parent call");
+
+$path = EDG::WP4::CCM::Path->new("/a/b/c");
+my $parent = $path->parent();
+isa_ok($parent, 'EDG::WP4::CCM::Path', 'parent returns a Path instance');
+# the stringifcation of $path shows that $path itself is unmodified
+is("$parent/c", "$path", "parent stringification works as expected with unmodified path");
 
 =head2 merge
 
@@ -115,6 +148,7 @@ ok ($path->down("{/a/b/c}") && ($path->toString() eq "/b/_2fa_2fb_2fc"), '$path-
 
 $path = EDG::WP4::CCM::Path->new("/a/b/c");
 isa_ok($path, "EDG::WP4::CCM::Path", "new returns EDG::WP4::CCM::Path instance");
+
 my $newpath = $path->merge();
 isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance 1");
 is_deeply($newpath, $path, "Merge with empty subpaths returns clone");
@@ -122,7 +156,104 @@ is("$newpath", "$path", "Stringification ok 1");
 
 $newpath = $path->merge("d", "e", "f", "{/a/b/c}");
 isa_ok($newpath, "EDG::WP4::CCM::Path", "merge returns EDG::WP4::CCM::Path instance 2");
+# the stringifcation of $path shows that $path itself is unmodified
 is("$newpath", "$path/d/e/f/_2fa_2fb_2fc", "Stringification ok 2");
+
+=head2 set_safe_unescape / reset_safe_unescape
+
+=cut
+
+$path = EDG::WP4::CCM::Path->new("/a/b/{/a/b/c}");
+
+# parent + subpath
+my @paths = qw(/a/b c /a/b {/a/b/c} /a/b/{/a/b/c}/e/f {x/y/z} /g/h {o/p/q});
+
+my $orig = [qw(/a/b/c /a/b/_2fa_2fb_2fc /a/b/_2fa_2fb_2fc/e/f/x_2fy_2fz /g/h/o_2fp_2fq)];
+my $safe_escaped = [qw(/a/b/c /a/b/{/a/b/c} /a/b/{/a/b/c}/e/f/{x/y/z} /g/h/o_2fp_2fq)];
+
+sub test_safe_unescape
+{
+    my ($topath) = @_;
+    my @res;
+    my $idx = 0;
+    while ($idx < scalar @paths) {
+        my $parent = EDG::WP4::CCM::Path->new($paths[$idx++]);
+        my $subpath = $paths[$idx++];
+
+        my $parentarg = $topath ? $parent : "$parent";
+
+        # very primitive
+        $subpath =~ s/^\{//;
+        $subpath =~ s/\}$//;
+        $subpath = escape($subpath);
+
+        push(@res, "$parent/".EDG::WP4::CCM::Path::_safe_unescape($parentarg, $subpath));
+    };
+
+    return \@res;
+}
+
+# return path stringifications or toString
+sub make_paths_strings
+{
+    my ($stringify) = @_;
+
+    my @res;
+    my $idx = 0;
+    while ($idx < scalar @paths) {
+        my $parent = $paths[$idx++];
+        my $subpath = $paths[$idx++];
+
+        my $path_instance = EDG::WP4::CCM::Path->new("$parent/$subpath");
+
+        push(@res, $stringify ? "$path_instance" : $path_instance->toString());
+    };
+    return \@res;
+}
+
+
+# To make sure it isn't set before, but there's no real way to check
+reset_safe_unescape();
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc'), '_2fa_2fb_2fc', 'basic _safe_unescape without safe_unescape 1');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc', 1), '_2fa_2fb_2fc', 'basic _safe_unescape trim without safe_unescape 1');
+is_deeply(test_safe_unescape(), $orig, "_safe_unescape without safe_unescape 1");
+is_deeply(test_safe_unescape(1), $orig, "_safe_unescape as Path without safe_unescape 1");
+is_deeply(make_paths_strings(), $orig, "path_strings as expected toString without safe_unescape 1");
+is_deeply(make_paths_strings(1), $orig, "path_strings as expected stringify without safe_unescape 1");
+is($path->get_last(), '_2fa_2fb_2fc', 'get_last without safe_unescape 1');
+is($path->get_last(1), '_2fa_2fb_2fc', 'get_last trim without safe_unescape 1');
+
+# Trailing slash should be stripped
+# Test parent with escaped path
+# Test no unneeded {}
+set_safe_unescape(qw(/a/b /a/b/{/a/b/c}/e/f/));
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc'), '{/a/b/c}', 'basic _safe_unescape with safe_unescape');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc', 1), '/a/b/c', 'basic _safe_unescape trim with safe_unescape');
+is_deeply(test_safe_unescape(), $safe_escaped, "_safe_unescape with safe_unescape");
+is_deeply(test_safe_unescape(1), $safe_escaped, "_safe_unescape as Path with safe_unescape");
+is_deeply(make_paths_strings(), $orig, "path_strings as expected toString with safe_unescape");
+is_deeply(make_paths_strings(1), $safe_escaped, "path_strings as expected stringify with safe_unescape");
+is($path->get_last(), '{/a/b/c}', 'get_last with safe_unescape');
+is($path->get_last(1), '/a/b/c', 'get_last trim with safe_unescape');
+
+reset_safe_unescape();
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc'), '_2fa_2fb_2fc', 'basic _safe_unescape without safe_unescape 2');
+is(EDG::WP4::CCM::Path::_safe_unescape('/a/b', '_2fa_2fb_2fc', 1), '_2fa_2fb_2fc', 'basic _safe_unescape trim without safe_unescape 2');
+is_deeply(test_safe_unescape(), $orig, "_safe_unescape without safe_unescape 2");
+is_deeply(test_safe_unescape(1), $orig, "_safe_unescape as Path without safe_unescape 2");
+is_deeply(make_paths_strings(), $orig, "path_strings as expected toString without safe_unescape 2");
+is_deeply(make_paths_strings(1), $orig, "path_strings as expected stringify without safe_unescape 2");
+is($path->get_last(), '_2fa_2fb_2fc', 'get_last without safe_unescape 2');
+is($path->get_last(1), '_2fa_2fb_2fc', 'get_last trim without safe_unescape 2');
+
+# Test set_safe_unescape without args
+reset_safe_unescape();
+set_safe_unescape();
+
+is(EDG::WP4::CCM::Path::_safe_unescape($EDG::WP4::CCM::Path::SAFE_UNESCAPE[0]."/", '_2fa_2fb_2fc'),
+   '{/a/b/c}', 'set_safe_unescape sets default SAFE_UNESCAPE as safe_unescape list');
+
+reset_safe_unescape();
 
 
 done_testing();

--- a/src/test/resources/tabcompletion_safe_unescape.pan
+++ b/src/test/resources/tabcompletion_safe_unescape.pan
@@ -1,0 +1,4 @@
+object template tabcompletion_safe_unescape;
+
+"/software/components/metaconfig/services/{/my/test/file}/contents/data" = 1;
+"/software/components/metaconfig/services/{/my/test2/file2}/contents/data" = 2;


### PR DESCRIPTION
Support using `{}` as in pan, and also the controlled unescaping of paths in CLI show and the generation of the tabcompletion file

Backwards incompatible because it changes some output formats