### PR TITLE
perl dependency JSON-XS: set an explicit requirement on RPM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,9 @@
         <requires>
           <require>perl(Crypt::SSLeay)</require>
           <require>perl(LWP::Protocol::https)</require>
-        </requires>
+          <!-- perl-JSON-XS rpm dependency set explicitly; EL5 metadata doesn't play nicely with 'perl(JSON::XS) >= 2.3.0'
+               set by 'use perl-JSON-XS 2.3.0' and version requirement is missing if 'use perl-JSON-XS v2.3.0' is used -->
+          <require>perl-JSON-XS &gt;= 2.3.0</require>        </requires>
         <mappings>
           <mapping>
             <directory>/usr/lib/perl/EDG/WP4/CCM</directory>

--- a/src/main/perl/JSONProfileSimple.pm
+++ b/src/main/perl/JSONProfileSimple.pm
@@ -31,7 +31,7 @@ use strict;
 use warnings;
 
 use EDG::WP4::CCM::Fetch qw(ComputeChecksum);
-use JSON::XS 2.3.0;
+use JSON::XS v2.3.0;
 
 $SIG{__DIE__} = \&confess;
 

--- a/src/main/perl/JSONProfileTyped.pm
+++ b/src/main/perl/JSONProfileTyped.pm
@@ -52,7 +52,7 @@ use strict;
 use warnings;
 
 use EDG::WP4::CCM::Fetch qw(ComputeChecksum);
-use JSON::XS 2.3.0;
+use JSON::XS v2.3.0;
 use B;
 use Scalar::Util qw(blessed);
 


### PR DESCRIPTION
Fixes #114 (YUM failure to match Perl-generated requirement on SL5)

This was intended to be a replacement for #115 (not working, see discussion for details) but ended up to be very close... #115 that must be closed when this one is merged. The summary is:
- Perl-generated requirement for version 2.3: doesn't work on SL6 as standard version is 2.27 and because Perl interprets versions as decimal numbers, 2.27 is less than 2.3...
- Perl requirement for v2.3 doesn't generate a RPM version requirement and thus YUM may install the EPEL version 1.47 that will not work, if a version > 2.3 is not present in any repo.

Successfully tested on both SL5 and SL6 (installation + ccm-fetch).