### PR TITLE
ccm-fetch report changed profile

### DIFF
--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -16,7 +16,7 @@ BEGIN {
 
 use CAF::Application;
 use CAF::Reporter;
-use LC::Exception qw(SUCCESS throw_error);
+use CAF::Object qw(SUCCESS throw_error);
 use EDG::WP4::CCM::Fetch qw(NOQUATTOR_FORCE);
 our @ISA = qw(CAF::Application CAF::Reporter);
 
@@ -168,7 +168,7 @@ use warnings;
 
 # modules
 use English;
-use LC::Exception qw(SUCCESS throw_error);
+use CAF::Object qw(SUCCESS CHANGED throw_error);
 use File::Basename;
 use EDG::WP4::CCM::Fetch qw(NOQUATTOR NOQUATTOR_EXITCODE NOQUATTOR_FORCE);
 use EDG::WP4::CCM::CacheManager;
@@ -281,7 +281,7 @@ $fetch->setPrincipal($this_app->option("principal"))
 $fetch->setKeytab($this_app->option("keytab"))
     if defined $this_app->option("keytab");
 
-#fetch rpofile
+# fetch profile
 my $errno = $fetch->fetchProfile();
 
 if (!defined($errno)) {
@@ -290,6 +290,10 @@ if (!defined($errno)) {
 } elsif ($errno == -1){
     $this_app->error("Unable to fetch profile");
     exit(1);
+} elsif ($errno == CHANGED) {
+    $this_app->info("Profile updated");
+} else {
+    $this_app->verbose("Fetched profile was not new");
 }
 
 exit (0);

--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -173,6 +173,7 @@ use File::Basename;
 use EDG::WP4::CCM::Fetch qw(NOQUATTOR NOQUATTOR_EXITCODE NOQUATTOR_FORCE);
 use EDG::WP4::CCM::CacheManager;
 use LC::Exception;
+use EDG::WP4::CCM::Fetch::ProfileCache qw($ERROR);
 
 $ENV{PATH} = join(":", qw(/bin /usr/bin /sbin /usr/sbin));
 
@@ -287,7 +288,7 @@ my $errno = $fetch->fetchProfile();
 if (!defined($errno)) {
     $this_app->error("Network error detected");
     exit(2);
-} elsif ($errno == -1){
+} elsif ($errno == $ERROR) {
     $this_app->error("Unable to fetch profile");
     exit(1);
 } elsif ($errno == CHANGED) {

--- a/src/main/perl/Fetch.pm
+++ b/src/main/perl/Fetch.pm
@@ -32,7 +32,7 @@ well as foreign node profiles.
 use strict;
 use warnings;
 
-use LC::Exception qw(SUCCESS throw_error);
+use CAF::Object qw(SUCCESS CHANGED throw_error);
 use Carp qw(carp confess);
 
 use constant NOQUATTOR          => "/etc/noquattor";
@@ -138,7 +138,10 @@ then the fetch will fail.
 
 Returns undef if it cannot fetch the profile due to a network error,
 C<<$EDG::WP4::CCM::Fetch::ProfileCache::ERROR>> in case of other failure,
-C<SUCCESS> in case of successful fetch.
+C<SUCCESS> in case of successful fetch, but no updated profile
+and C<CHANGED> in case of successful fetch and
+updated profile.
+
 
 =cut
 
@@ -214,7 +217,7 @@ sub fetchProfile
         # An error is logged in case of problem
         $self->generate_tabcompletion($new_cid) if $self->{TABCOMPLETION};
 
-        $res = SUCCESS;
+        $res = CHANGED;
     }
 
     return $res;

--- a/src/test/perl/fetch.t
+++ b/src/test/perl/fetch.t
@@ -22,10 +22,9 @@ use EDG::WP4::CCM::Fetch qw($GLOBAL_LOCK_FN $FETCH_LOCK_FN
 use EDG::WP4::CCM::Configuration;
 use Cwd qw(getcwd);
 use File::Path qw(mkpath rmtree);
-use CAF::Object;
+use CAF::Object qw(SUCCESS CHANGED);
 use Carp qw(croak);
 use CAF::Reporter;
-use LC::Exception qw(SUCCESS);
 
 use Test::Quattor::TextRender::Base;
 use Test::MockModule;
@@ -475,7 +474,7 @@ We expect it:
 # At this point, the profile is defined as a JSON profile...
 # First download the profile to be sure that it is already there
 # before the test.
-is($f->fetchProfile(), SUCCESS, "Initial fetchProfile worked correctly (JSON profile)");
+is($f->fetchProfile(), CHANGED, "Initial fetchProfile worked correctly (JSON profile)");
 $f->{FORCE} = 0;
 is($f->fetchProfile(), SUCCESS, "fetchProfile of the same JSON profile succeeded");
 is($f->{FORCE}, 0, "And the FORCE flag was not modified 1");
@@ -489,7 +488,7 @@ is($f->{FORCE}, 0, "And the FORCE flag was not modified 1");
 $f->{PROFILE_URL} =~ s{json}{xml};
 $f->{FORCE} = 0;
 $f->setup_reporter(0, 0, 1);
-is($f->fetchProfile(), SUCCESS, "fetchProfile worked correctly on XML profile");
+is($f->fetchProfile(), CHANGED, "fetchProfile worked correctly on XML profile");
 is($f->{FORCE}, 1, "A change in the URL forces to re-download");
 # Check that FORCE flag is also respected/not modified with XML profile in case of
 # format-specific issue.
@@ -507,8 +506,8 @@ is($f->{TABCOMPLETION}, 0, "tabcompletion generation off");
 
 $f->{FORCE} = 1;
 $f->{TABCOMPLETION} = 1;
-is($f->fetchProfile(), SUCCESS,
-   "fetchProfile worked correctly on the same XML profile (with tabcompletion enabled)");
+is($f->fetchProfile(), CHANGED,
+   "fetchProfile worked correctly on the same XML profile (with force and tabcompletion enabled)");
 
 my %latest = $f->previous();
 


### PR DESCRIPTION
Fixes #75

Backwards incompatible due to change in possible return value of `CCM::Fetch->fetchProfile`.
Requires https://github.com/quattor/aii/pull/207 (otherwise this breaks AII)