### PR TITLE
Use a branch type value allowed by the schema when testing

### DIFF
--- a/src/test/perl/configuration-name.t
+++ b/src/test/perl/configuration-name.t
@@ -78,7 +78,7 @@ my $cfg4 = $cfg->{cache_manager}->getConfiguration(undef, $cfg->{cid}, name_temp
 is_deeply($cfg4->{name}, {template => 'basic'},
           "name template basic passed, name attribute set");
 $cfg4->{fail} = undef;
-is($cfg4->getName(), "mybranch-production-user123-3b91b01-1476014841", "correct name with template name basic");
+is($cfg4->getName(), "mybranch-sandbox-user123-3b91b01-1476014841", "correct name with template name basic");
 ok(! defined($cfg4->{fail}), "getName does not set fail attr with correct rendered name");
 
 # unknown type

--- a/src/test/resources/names.pan
+++ b/src/test/resources/names.pan
@@ -5,7 +5,7 @@ bind '/metadata' = structure_metadata;
 
 prefix "/metadata/template/branch";
 "name" = "mybranch";
-"type" = "production";
+"type" = "sandbox";
 "author" = "user123";
 "commit-id" = "3b91b01";
 "timestamp" = 1476014841;


### PR DESCRIPTION
quattor/template-library-core#147 introduced validation for the branch type which caused this test to fail, using a supported value fixes this.