### PR TITLE
ccm-purge: Use correct (new) path for DB module

### DIFF
--- a/src/main/bin/ccm-purge
+++ b/src/main/bin/ccm-purge
@@ -16,7 +16,7 @@ use Digest::MD5 qw(md5_hex);
 use Errno qw(ESRCH EPERM);
 use File::Path;
 use EDG::WP4::CCM::CCfg qw(initCfg);
-use EDG::WP4::CCM::DB qw(read_db);
+use EDG::WP4::CCM::CacheManager::DB qw(read_db);
 use LC::Stat qw(:ST);
 
 #


### PR DESCRIPTION
This was missed when CCM was restructured in 1713a0348163d79c3ba44ee3f5c7d4129097b68c (merged in 4d4b1c025bdbd632f2a8699ee552eb5d136d262a).

Fixes #175.