### PR TITLE
remove '.' from @INC

### DIFF
--- a/src/main/bin/ccm
+++ b/src/main/bin/ccm
@@ -10,6 +10,7 @@ use warnings;
 # required for CAF
 BEGIN {
     unshift(@INC, '/usr/lib/perl');
+    pop @INC if $INC[-1] eq '.';
 }
 
 # minimal Path

--- a/src/main/bin/ccm-fetch
+++ b/src/main/bin/ccm-fetch
@@ -12,6 +12,7 @@ use warnings;
 # required for CAF (Common Application Framework)
 BEGIN {
     unshift(@INC, '/usr/lib/perl');
+    pop @INC if $INC[-1] eq '.';
 }
 
 use CAF::Application;

--- a/src/main/bin/ccm-initialise
+++ b/src/main/bin/ccm-initialise
@@ -14,6 +14,7 @@ use warnings;
 
 BEGIN {
     unshift(@INC, '/usr/lib/perl');
+    pop @INC if $INC[-1] eq '.';
 }
 
 use CAF::Application;

--- a/src/main/bin/ccm-purge
+++ b/src/main/bin/ccm-purge
@@ -9,6 +9,7 @@ use warnings;
 
 BEGIN {
     unshift(@INC, '/usr/lib/perl');
+    pop @INC if $INC[-1] eq '.';
 }
 
 use Getopt::Long;


### PR DESCRIPTION
As described in the link below:
http://search.cpan.org/dist/perl-5.26.0/pod/perldelta.pod#Removal_of_the_current_directory_(%22.%22)_from_@INC

Perls before 5.26 include dot in INC unless taint mode is enabled.
Most script supplied by quattor does have taint enabled except a few.

Here I am using the recommendation to remove dot from `@INC`. This is safe
invocation as if someone enables taint mode or upgrades perl it still does the
right thing.