### PR TITLE
CacheManager::DB: set CLOEXEC on tied DB files

### DIFF
--- a/src/main/perl/CLI.pm
+++ b/src/main/perl/CLI.pm
@@ -2,7 +2,7 @@
 
 use parent qw(EDG::WP4::CCM::Options);
 use CAF::Object qw(SUCCESS);
-use EDG::WP4::CCM::CacheManager::DB qw(read_db);
+use EDG::WP4::CCM::CacheManager::DB qw(read_db close_db);
 use EDG::WP4::CCM::CacheManager::Encode qw(encode_eids decode_eid $PATH2EID $EID2DATA @EIDS_PACK);
 use EDG::WP4::CCM::TextRender qw(ccm_format @CCM_FORMATS);
 use EDG::WP4::CCM::Path qw(set_safe_unescape reset_safe_unescape);
@@ -144,8 +144,8 @@ sub action_dumpdb
         my $err = read_db($db->[1], "$prof_dir/$db->[0]");
         if ($err) {
             $self->error("could not read $prof_dir/$db->[0]: $err\n");
-            untie(%path2eid);
-            untie(%eid2data);
+            close_db("$prof_dir/$PATH2EID");
+            close_db("$prof_dir/$EID2DATA");
             return;
         }
     };
@@ -172,8 +172,8 @@ sub action_dumpdb
         };
     }
 
-    untie(%path2eid);
-    untie(%eid2data);
+    close_db("$prof_dir/$PATH2EID");
+    close_db("$prof_dir/$EID2DATA");
 
     return SUCCESS;
 }

--- a/src/main/perl/CacheManager/DB.pm
+++ b/src/main/perl/CacheManager/DB.pm
@@ -32,10 +32,11 @@ use CAF::Object qw(SUCCESS);
 use CAF::FileWriter;
 use CAF::FileReader;
 use Module::Load;
+use Fcntl;
 
 use Readonly;
 
-our @EXPORT_OK = qw(read_db);
+our @EXPORT_OK = qw(read_db close_db close_db_all);
 
 # Upon change, modify the write and open pod
 Readonly our $DEFAULT_FORMAT => 'DB_File';
@@ -77,6 +78,61 @@ Readonly::Hash my %DB_GDBM_DISPATCH => {
     GDBM_File_write => sub {return &GDBM_WRCREAT;},
 };
 
+# Hashref of open filehandles / ties / references for (C)DB_File ties
+#   they are kept here so the filehandles created to set CLOEXEC flag
+#   on an read-only DB_File tie (and this prevents them to go out of scope,
+#   and closing the underlying filehandle of the tie)
+# We need to keep proper track of them, to be able to properly clean them up.
+my $_dbs = {};
+
+# Close all _dbs of certain flaovur (e.g. all eid2path)
+sub close_db_all
+{
+    my $flavour = shift;
+    foreach my $path (keys %$_dbs) {
+        close_db($path) if $path =~ m/$flavour/;
+    }
+}
+
+# Close a db associated with certain file
+sub close_db
+{
+    my ($path) = @_;
+
+    # proper order:
+    #   destroy tie
+    #   untie hash
+    #   cleanup open filehandles
+
+    undef $_dbs->{$path}->{tie};
+
+    local $@;
+
+    eval {
+        untie %{$_dbs->{$path}->{ref}};
+    };
+    undef $_dbs->{$path}->{ref};
+
+    eval {
+        close $_dbs->{$path}->{fh};
+    };
+    undef $_dbs->{$path}->{fh};
+
+    delete $_dbs->{$path};
+}
+
+# Set FD_CLOEXEC on filehandle
+# Return undef on success, error message on failure
+sub cloexec
+{
+    my ($path, $msg) = @_;
+    my $flags = fcntl($_dbs->{$path}->{fh}, F_GETFL, 0);
+    if (fcntl($_dbs->{$path}->{fh}, F_SETFL, $flags & FD_CLOEXEC)) {
+        return;
+    } else {
+        return "Can't set flags$msg: $!\n";
+    }
+}
 
 =item new / _initialize
 
@@ -122,19 +178,31 @@ sub _DB_GDBM_File
     $to_tie = \%out if ($mode eq "write");
 
     # mode as restricted as possible
-    my $tie = tie(%$to_tie, $dbformat, $file, $flags, oct(600), @extras);
+    close_db($file);
+    $_dbs->{$file}->{ref} = $to_tie;
+    $_dbs->{$file}->{tie} = tie(%$to_tie, $dbformat, $file, $flags, oct(600), @extras);
 
-    if ($tie) {
+    my $err;
+    if ($_dbs->{$file}->{tie}) {
         if ($mode eq 'write') {
             %out = %$hashref;
-            $tie = undef;    # avoid "untie attempted while 1 inner references still exist" warnings
-            untie(%out) or return "can't untie $dbformat $file: $!";
+            close_db($file);
+        } else {
+            # This is not supported for GDBM
+            if ($_dbs->{$file}->{tie}->can('fd')) {
+                # do not use dup (this is inspired by the old way to lock DB_File)
+                if (open($_dbs->{$file}->{fh}, '<&=', $_dbs->{$file}->{tie}->fd())) {
+                    $err = cloexec($file, "from $dbformat $file");
+                } else {
+                    $err = "Failed to get filehandle from $dbformat $file: $!";
+                }
+            }
         }
     } else {
-        return "failed to open $dbformat $file for $mode: $!";
+        $err = "failed to open $dbformat $file for $mode: $!";
     }
 
-    return;
+    return $err;
 }
 
 # Interact with CDB_File
@@ -152,12 +220,21 @@ sub _CDB_File
         };
         $err = $@;
     } else {
-        $err = $! if (!tie(%$hashref, $dbformat, $file));
+        close_db($file);
+        $_dbs->{$file}->{ref} = $hashref;
+        $_dbs->{$file}->{tie} = tie(%$hashref, $dbformat, $file);
+        if ($_dbs->{$file}->{tie}) {
+            if ($_dbs->{$file}->{tie}->can('handle')) {
+                $_dbs->{$file}->{fh} = $_dbs->{$file}->{tie}->handle();
+                $err = cloexec($file, "from $dbformat $file");
+            }
+        } else {
+            $err = $!;
+        }
     }
-    if ($err) {
-        return "failed to open $dbformat $file for $mode: $err";
-    }
-    return;
+    $err = "failed to open $dbformat $file for $mode: $err" if $err;
+
+    return $err ? $err : undef;
 }
 
 =item test_supported_format
@@ -265,9 +342,7 @@ sub open
     $self->verbose("Reading the database to $db_fn using $dbformat");
 
     my $err = $FORMAT_DISPATCH{$dbformat}->($hashref, $db_fn, 'read');
-    return $err if (defined($err));
-
-    return;
+    return $err;
 }
 
 =back

--- a/src/main/perl/CacheManager/Element.pm
+++ b/src/main/perl/CacheManager/Element.pm
@@ -5,7 +5,7 @@ use File::Spec;
 use Encode qw(decode_utf8);
 use LC::Exception qw(SUCCESS throw_error);
 use EDG::WP4::CCM::CacheManager::Resource;
-use EDG::WP4::CCM::CacheManager::DB qw(read_db);
+use EDG::WP4::CCM::CacheManager::DB qw(read_db close_db_all);
 use EDG::WP4::CCM::CacheManager::Encode qw(
     PROPERTY RESOURCE
     STRING LONG DOUBLE BOOLEAN
@@ -171,7 +171,9 @@ profile data goes into a whole new path.)
             my %newhash = ();
             $CACHE->{$base}->{path} = $path;
 
-            # Should any old references be untied here?
+            # Cleanup/untie any other references
+            close_db_all($base);
+
             $CACHE->{$base}->{db} = \%newhash;
             $CACHE->{$base}->{err} = read_db(\%newhash, $path);
         }

--- a/src/test/perl/db.t
+++ b/src/test/perl/db.t
@@ -84,7 +84,7 @@ sub test_fmt {
 
     my $pref = "$dbd/".lc($name);
     my $db = EDG::WP4::CCM::CacheManager::DB->new($pref, log => $obj);
-    my $err= $db->write($DATA, $fmt, {mode => 0604}); # very non-standard mode
+    my $err = $db->write($DATA, $fmt, {mode => 0604}); # very non-standard mode
 
     ok(! defined($err), "No error while writing $name");
     ok(-f "$pref.db", "$name db file found");
@@ -94,12 +94,16 @@ sub test_fmt {
 
     my $data = {};
     $err = read_db($data, $pref);
+    diag "YY",$err if defined $err;
+    diag explain $data;
     ok(! defined($err), "No error while reading $name");
     is_deeply($data, $DATA, "Read correct data structure for $name");
 
     # Test legacy read
     my $datal = {};
     $err = EDG::WP4::CCM::CacheManager::DB::read($datal, $pref);
+    diag "XX",$err if defined $err;
+    diag explain $datal;
     ok(! defined($err), "No error while reading $name legacy read");
     is_deeply($datal, $DATA, "Read correct data structure for $name legacy read");
 }


### PR DESCRIPTION
File descriptors are passed to child processes on POSIX platforms by design,
in the case of CCM, this can lead to these being passed all the way down the call tree
to processes (e.g. daemons) that are started by components.
Setting CLOEXEC disables this behaviour and fixes the potential security risk that this poses.

This problem is tackled in modern OSes in e.g. glibc or even Perl itself when using regular open.
However, this is still an issue for the CCM DB files, since we pass our own flags, bypassing
the default behaviour.