### PR TITLE
CCM::Configuration: remove reference to placeholder

### DIFF
--- a/src/main/perl/CacheManager/Configuration.pm
+++ b/src/main/perl/CacheManager/Configuration.pm
@@ -1,7 +1,5 @@
 #${PMpre} EDG::WP4::CCM::CacheManager::Configuration${PMpost}
 
-use parent qw(EDG::WP4::CCM::Configuration);
-
 use POSIX qw (getpid);
 use LC::Exception qw(SUCCESS throw_error);
 use EDG::WP4::CCM::CacheManager::Element;


### PR DESCRIPTION
Last part of #169, was overlooked in #187.
Blocking for 18.6.