### PR TITLE
Add /var/lib/ccm to the RPM package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,10 @@
             </sources>
             <directoryIncluded>false</directoryIncluded>
           </mapping>
+          <mapping>
+            <directory>/var/lib/ccm</directory>
+            <filemode>755</filemode>
+          </mapping>
         </mappings>
         <postinstallScriptlet>
           <script>pgrep ncm-cdispd &gt;/dev/null &amp;&amp; service ncm-cdispd restart || true</script>


### PR DESCRIPTION
This avoids an error when ncm-cdispd is installed by Anaconda before any
Quattor components would be able to create the directory. It also
creates an official record of who owns the directory, which is also nice.