### PR TITLE
ccm-purge: Fix cleaning up $CacheDir/data

### DIFF
--- a/src/main/bin/ccm-purge
+++ b/src/main/bin/ccm-purge
@@ -18,6 +18,7 @@ use Errno qw(ESRCH EPERM);
 use File::Path;
 use EDG::WP4::CCM::CCfg qw(initCfg);
 use EDG::WP4::CCM::CacheManager::DB qw(read_db close_db);
+use EDG::WP4::CCM::Fetch::Download;
 use LC::Stat qw(:ST);
 
 #
@@ -254,8 +255,8 @@ sub save_active_urls
     # in files profile.url
 
     my $url = read_url("${CacheDir}/${profile}/profile.url");
-    my $md5 = md5_hex($url);
-    delete($NonactiveURL{$md5});
+    my $encoded_url = EDG::WP4::CCM::Fetch::Download->EncodeURL($url);
+    delete($NonactiveURL{$encoded_url});
 
     # search URLs in fetch porperties
     my %hash;
@@ -270,8 +271,8 @@ sub save_active_urls
         $ukey = $ukey & 0xEFFFFFFF;
         $key = pack("L", $ukey);
         $url = $hash{$key};
-        $md5 = md5_hex($url);
-        delete( $NonactiveURL{$md5} );
+        my $encoded_url = EDG::WP4::CCM::Fetch::Download->EncodeURL($url);
+        delete( $NonactiveURL{$encoded_url} );
     }
 
     close_db($fn);


### PR DESCRIPTION
Make sure ccm-pruge uses the same URL encoding method as
Fetch::Download, to avoid removing URLs which are in fact still valid.

Fixes issue #124.