### PR TITLE
Strip out all references to derivation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
           </mapping>
         </mappings>
         <postinstallScriptlet>
-          <script>pgrep ncm-cdispd &gt;/dev/null &amp;&amp; service ncm-cdispd restart || true</script>
+          <script>ccm-fetch -f; pgrep ncm-cdispd &gt;/dev/null &amp;&amp; service ncm-cdispd restart || true</script>
         </postinstallScriptlet>
       </configuration>
     </plugin>

--- a/src/main/perl/CacheManager/Element.pm
+++ b/src/main/perl/CacheManager/Element.pm
@@ -31,7 +31,6 @@ EDG::WP4::CCM::CacheManager::Element - Element class
     $name = $element->getName();
     $path = $element->getPath()
     $type = $element->getType();
-    $derivation = $element->getDerivation();
     $checksum = $element->getChecksum();
     $description = $element->getDescription();
     $value = $element->getValue();
@@ -86,7 +85,6 @@ sub new
     $self->{EID}         = undef;
     $self->{PATH}        = undef;           # should be a Path object
     $self->{TYPE}        = undef;           # should a valid TYPE constant)
-    $self->{DERIVATION}  = undef;
     $self->{CHECKSUM}    = undef;
     $self->{DESCRIPTION} = undef;
     $self->{VALUE}       = undef;
@@ -331,18 +329,6 @@ sub getType
 {
     my $self = shift;
     return $self->{TYPE};
-}
-
-=item getDerivation()
-
-Returns the element's derivation
-
-=cut
-
-sub getDerivation
-{
-    my $self = shift;
-    return $self->{DERIVATION};
 }
 
 =item getChecksum()
@@ -660,14 +646,12 @@ sub _read_metadata
         return;
     }
 
-    foreach my $md (qw(TYPE DERIVATION CHECKSUM DESCRIPTION)) {
+    foreach my $md (qw(TYPE CHECKSUM DESCRIPTION)) {
         my $val = $hashref->{$keys->{$md}};
         if (defined($val)) {
             $self->{$md} = $val;
-        } elsif ($md eq 'DESCRIPTION' || $md eq 'DERIVATION') {
+        } elsif ($md eq 'DESCRIPTION') {
             # metadata attribute "description" is optional
-            # TODO: metadata attribute "derivation" should not be optional
-            #       but eg none of the JSONProfile have it
             $self->{$md} = "";
         } else {
             throw_error("failed to read element's $md eid $self->{EID}");

--- a/src/main/perl/CacheManager/Encode.pm
+++ b/src/main/perl/CacheManager/Encode.pm
@@ -44,7 +44,7 @@ Readonly::Hash our %NAME_TYPE_MAP => {
 
 # sorted names to compute pack'ed values for
 # using offset based on index in this array
-Readonly::Array our @EIDS_PACK => qw(VALUE TYPE DERIVATION CHECKSUM DESCRIPTION);
+Readonly::Array our @EIDS_PACK => qw(VALUE TYPE CHECKSUM DESCRIPTION);
 
 # DB filenames (typically in profilepath)
 Readonly our $PATH2EID => 'path2eid';
@@ -144,7 +144,7 @@ sub decode_eid
 =item encode_eids
 
 Given C<eid>, return the keys of the tie'ed DB hashref
-for C<VALUE>, C<TYPE>, C<DERIVATION>, C<CHECKSUM> and C<DESCRIPTION>
+for C<VALUE>, C<TYPE>, C<CHECKSUM> and C<DESCRIPTION>
 as used in the C<eid2data> DB.
 
 =cut

--- a/src/main/perl/CacheManager/Resource.pm
+++ b/src/main/perl/CacheManager/Resource.pm
@@ -45,7 +45,7 @@ sub new
     my $self  = $class->SUPER::new(@_);
 
     # check that element it is really a resource
-    if (!$self->isResource()) {
+    if (defined $self && !$self->isResource()) {
         throw_error("element is not of type Resource");
         return ();
     }

--- a/src/main/perl/Fetch/ProfileCache.pm
+++ b/src/main/perl/Fetch/ProfileCache.pm
@@ -471,7 +471,7 @@ sub AddPath
     # store attributes
     my $t = defined $tree->{USERTYPE} ? $tree->{USERTYPE} : $type;
     $eid2data->{$eids->{TYPE}} = $t;
-    foreach my $md (qw(DERIVATION CHECKSUM DECRIPTION)) {
+    foreach my $md (qw(CHECKSUM DECRIPTION)) {
         $eid2data->{$eids->{$md}} = $tree->{$md} if (defined $tree->{$md});
     }
 }

--- a/src/main/perl/Fetch/XMLPanProfile.pm
+++ b/src/main/perl/Fetch/XMLPanProfile.pm
@@ -33,7 +33,6 @@ use constant INTERPRETERS => {
 
 use constant VALID_ATTRIBUTES => {
     NAME        => 1,
-    DERIVATION  => 1,
     CHECKSUM    => 1,
     ACL         => 1,
     ENCODING    => 1,

--- a/src/test/perl/cli.t
+++ b/src/test/perl/cli.t
@@ -79,10 +79,10 @@ like($txt,
      "dumpdb output path2eid");
 # \0 separated list of subpaths
 like($txt,
-     qr{eid2data:\n0 => a\0c\0e\n10000000 => nlist\n30000000 => 1740877ebcb53b5132e75cff986cd705\n1 => b}m,
+     qr{eid2data:\n0 => a\0c\0e\n10000000 => nlist\n20000000 => 1740877ebcb53b5132e75cff986cd705\n1 => b}m,
      "dumpdb output eid2data");
 like($txt,
-     qr{path2eid and eid2data combined:\n/ \(0\) =>\n  V: a\0c\0e\n  T: nlist\n  D: <undef>\n  C: 1740877ebcb53b5132e75cff986cd705\n  D: <undef>\n/a \(1\) =>\n},
+     qr{path2eid and eid2data combined:\n/ \(0\) =>\n  V: a\0c\0e\n  T: nlist\n  C: 1740877ebcb53b5132e75cff986cd705\n  D: <undef>\n/a \(1\) =>\n},
      "dumpdb ouptut combined path2eid eid2data");
 diag $txt;
 

--- a/src/test/perl/element.t
+++ b/src/test/perl/element.t
@@ -31,8 +31,7 @@ sub gen_dbm ($$) {
 
     my ($cache_dir, $profile) = @_;
     my (%hash);
-    my ($key, $val, $active);
-    my ($derivation);
+    my ($key, $val, $type, $active);
 
     # remove previous cache dir
 
@@ -62,46 +61,39 @@ sub gen_dbm ($$) {
         &O_RDWR|&O_CREAT, 0644) or return();
     # value
     $key = 0x00000001;
-    $hash{pack("L", $key)} = "a string";
+    $val = "a string";
+    $hash{pack("L", $key)} = $val;
     # type
     $key = 0x10000001;
-    $hash{pack("L", $key)} = "string";
-    # derivation
-    $key = 0x20000001;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L", $key)} = $derivation;
+    $type = "string";
+    $hash{pack("L", $key)} = $type;
     # checksum
-    $key = 0x30000001;
-    $hash{pack("L", $key)} = md5_hex($derivation);
+    $key = 0x20000001;
+    $hash{pack("L", $key)} = md5_hex("$val|$type");
     # description
-    $key = 0x40000001;
+    $key = 0x30000001;
     $hash{pack("L", $key)} = "an example of string";
 
     # value
     $key = 0x00000002;
-    $hash{pack("L", $key)} = "a list";
+    $val = "a list";
+    $hash{pack("L", $key)} = $val;
     # type
     $key = 0x10000002;
-    $hash{pack("L", $key)} = "list";
-    # derivation
-    $key = 0x20000002;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L", $key)} = $derivation;
+    $type = "list";
+    $hash{pack("L", $key)} = $type;
     # checksum
-    $key = 0x30000002;
-    $hash{pack("L", $key)} = md5_hex($derivation);
+    $key = 0x20000002;
+    $hash{pack("L", $key)} = md5_hex("$val|$type");
     # description
-    $key = 0x40000002;
+    $key = 0x30000002;
     $hash{pack("L", $key)} = "an example of list";
 
     untie(%hash);
-
-    return (1);
-
 }
 
 my ($element, $property, $resource, $path);
-my ($type, $derivation, $checksum, $description, $value);
+my ($type, $checksum, $description, $value);
 my ($string);
 
 my ($cm, $config, $cache_dir, $profile);
@@ -161,14 +153,9 @@ is($string, "/path/to/property", "Element->getPath()");
 $type = $element->getType();
 is($type, EDG::WP4::CCM::CacheManager::Element->STRING, "Element->getType()" );
 
-# test getDerivation()
-$derivation = $element->getDerivation();
-is($derivation, "lxplus.tpl,hardware.tpl,lxplust_025.tpl",
-   "Element->getDerivation()");
-
 # test getChecksum()
 $checksum = $element->getChecksum();
-is($checksum, md5_hex($derivation), "Element->getChecksum()");
+is($checksum, md5_hex("a string|string"), "Element->getChecksum()");
 
 # test getDescription()
 $description = $element->getDescription();

--- a/src/test/perl/encode.t
+++ b/src/test/perl/encode.t
@@ -34,15 +34,14 @@ foreach my $name (sort keys %map) {
 is(type_from_name('something'), UNDEFINED, "type_from_name returns UNDEFINED");
 
 is_deeply(\@EIDS_PACK,
-          [qw(VALUE TYPE DERIVATION CHECKSUM DESCRIPTION)],
+          [qw(VALUE TYPE CHECKSUM DESCRIPTION)],
           "EIDS_PACK array");
 
 is_deeply(encode_eids(123), {
     VALUE => pack('L', 123),
     TYPE => pack('L', 1 << 28 | 123),
-    DERIVATION => pack('L', 2 << 28 | 123),
-    CHECKSUM => pack('L', 3 << 28 | 123),
-    DESCRIPTION => pack('L', 4 << 28 | 123),
+    CHECKSUM => pack('L', 2 << 28 | 123),
+    DESCRIPTION => pack('L', 3 << 28 | 123),
 }, "encode_eids for id 123");
 
 is(decode_eid(encode_eids(123)->{VALUE}), 123, "decode encoded eid returns original");

--- a/src/test/perl/property.t
+++ b/src/test/perl/property.t
@@ -28,8 +28,7 @@ sub gen_dbm
 {
     my ($cache_dir, $profile) = @_;
     my (%hash);
-    my ($key, $val, $active);
-    my ($derivation);
+    my ($key, $val, $type, $active);
 
     # create new profile
     mkdir("$cache_dir");
@@ -52,21 +51,23 @@ sub gen_dbm
 
     tie(%hash, "DB_File", "${cache_dir}/${profile}/eid2data.db",
         &O_RDWR|&O_CREAT, 0644) or return();
+
     # value
     $key = 0x00000001;
-    $hash{pack("L", $key)} = "a string";
+    $val = "a string";
+    $hash{pack("L", $key)} = $val;
+
     # type
     $key = 0x10000001;
-    $hash{pack("L", $key)} = "string";
-    # derivation
-    $key = 0x20000001;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L", $key)} = $derivation;
+    $type = "string";
+    $hash{pack("L", $key)} = $type;
+
     # checksum
-    $key = 0x30000001;
-    $hash{pack("L", $key)} = md5_hex($derivation);
+    $key = 0x20000001;
+    $hash{pack("L", $key)} = md5_hex("$val|$type");
+
     # description
-    $key = 0x40000001;
+    $key = 0x30000001;
     $hash{pack("L", $key)} = "an example of string";
     untie(%hash);
 
@@ -102,13 +103,8 @@ is($getpath->toString(), "/path/to/element", "property Element->getPath()");
 # test getType()
 is($property->getType(), EDG::WP4::CCM::CacheManager::Element->STRING, "property Element->getType() is STRING");
 
-# test getDerivation()
-my $derivation = $property->getDerivation();
-is($derivation, "lxplus.tpl,hardware.tpl,lxplust_025.tpl",
-   "property Element->getDerivation()");
-
 # test getChecksum()
-is($property->getChecksum(), md5_hex($derivation), "property Element->getChecksum()");
+is($property->getChecksum(), md5_hex("a string|string"), "property Element->getChecksum()");
 
 # test getDescription()
 is($property->getDescription(), "an example of string", "property Element->getDescription()");

--- a/src/test/perl/resource.t
+++ b/src/test/perl/resource.t
@@ -8,7 +8,7 @@ use warnings;
 use POSIX qw (getpid);
 use DB_File;
 use Digest::MD5 qw(md5_hex);
-use Test::Simple tests => 42;
+use Test::Simple tests => 41;
 use LC::Exception qw(SUCCESS throw_error);
 
 use EDG::WP4::CCM::CacheManager qw ($DATA_DN $GLOBAL_LOCK_FN
@@ -21,7 +21,7 @@ use EDG::WP4::CCM::Path;
 use CCMTest qw (eok make_file);
 
 my ($resource, $path, $string, $type);
-my ($derivation, $checksum, $description, $value);
+my ($checksum, $description, $value);
 
 my ($cm, $config, $cache_dir, $profile, %hash, $key, @array, $i, $name);
 
@@ -42,7 +42,7 @@ sub gen_dbm ($$) {
 
     my ($cache_dir, $profile) = @_;
     my (%hash);
-    my ($key, $val, $active);
+    my ($key, $val, $type, $active);
 
     # create new profile
     mkdir("$cache_dir");
@@ -56,8 +56,7 @@ sub gen_dbm ($$) {
     $active = $profile . "/active." . getpid();
     make_file("$cache_dir/$active", "1\n");
 
-    tie(%hash, "DB_File", "${cache_dir}/${profile}/path2eid.db",
-        &O_RDWR|&O_CREAT, 0644) or return();
+    tie(%hash, "DB_File", "${cache_dir}/${profile}/path2eid.db", &O_RDWR|&O_CREAT, 0644) or return();
 
     $key = "/path/to/list";
     $value = 0x00000001;
@@ -90,106 +89,110 @@ sub gen_dbm ($$) {
 
     # value
     $key = 0x00000001;
-    $hash{pack("L",$key)} = chr(48).chr(0).chr(49);
+    $value = chr(48).chr(0).chr(49);
+    $hash{pack("L",$key)} = $value;
+
     # type
     $key = 0x10000001;
-    $hash{pack("L",$key)} = "list";
-    # derivation
-    $key = 0x20000001;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type  = "list";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000001;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000001;
+    $hash{pack("L",$key)} = md5_hex("$value|$type");
+
     # description
-    $key = 0x40000001;
+    $key = 0x30000001;
     $hash{pack("L",$key)} = "an example of list";
 
     # value
     $key = 0x00000002;
-    $hash{pack("L",$key)} = "element 0";
+    $value = "element 0";
+    $hash{pack("L",$key)} = $value;
+
     # type
     $key = 0x10000002;
-    $hash{pack("L",$key)} = "string";
-    # derivation
-    $key = 0x20000002;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type = "string";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000002;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000002;
+    $hash{pack("L",$key)} = md5_hex("$key|$value");
+
     # description
-    $key = 0x40000002;
+    $key = 0x30000002;
     $hash{pack("L",$key)} = "an example of string";
 
     # value
     $key = 0x00000003;
-    $hash{pack("L",$key)} = "element 1";
+    $value = "element 1";
+    $hash{pack("L",$key)} = $value;
+
     # type
     $key = 0x10000003;
-    $hash{pack("L",$key)} = "string";
-    # derivation
-    $key = 0x20000003;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type = "string";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000003;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000003;
+    $hash{pack("L",$key)} = md5_hex("$key|$value");
+
     # description
-    $key = 0x40000003;
+    $key = 0x30000003;
     $hash{pack("L",$key)} = "an example of string";
 
     # value
     $key = 0x00000004;
-    $hash{pack("L",$key)} = $hash{pack("L",$key)} =
-       chr(122).chr(101).chr(114).chr(111).chr(0).chr(111).chr(110).chr(101);
+    $value = chr(122).chr(101).chr(114).chr(111).chr(0).chr(111).chr(110).chr(101);
+    $hash{pack("L",$key)} = $value;
 
     # type
     $key = 0x10000004;
-    $hash{pack("L",$key)} = "nlist";
-    # derivation
-    $key = 0x20000004;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type = "nlist";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000004;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000004;
+    $hash{pack("L",$key)} = md5_hex("$key|$value");
+
     # description
-    $key = 0x40000004;
+    $key = 0x30000004;
     $hash{pack("L",$key)} = "an example of nlist";
 
     # value
     $key = 0x00000005;
-    $hash{pack("L",$key)} = "element zero";
+    $value = "element zero";
+    $hash{pack("L",$key)} = $value;
+
     # type
     $key = 0x10000005;
-    $hash{pack("L",$key)} = "string";
-    # derivation
-    $key = 0x20000005;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type = "string";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000005;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000005;
+    $hash{pack("L",$key)} = md5_hex("$key|$value");
+
     # description
-    $key = 0x40000005;
+    $key = 0x30000005;
     $hash{pack("L",$key)} = "an example of string";
 
     # value
     $key = 0x00000006;
-    $hash{pack("L",$key)} = "element one";
+    $value = "element one";
+    $hash{pack("L",$key)} = $value;
+
     # type
     $key = 0x10000006;
-    $hash{pack("L",$key)} = "string";
-    # derivation
-    $key = 0x20000006;
-    $derivation = "lxplus.tpl,hardware.tpl,lxplust_025.tpl";
-    $hash{pack("L",$key)} = $derivation;
+    $type = "string";
+    $hash{pack("L",$key)} = $type;
+
     # checksum
-    $key = 0x30000006;
-    $hash{pack("L",$key)} = md5_hex($derivation);;
+    $key = 0x20000006;
+    $hash{pack("L",$key)} = md5_hex("$key|$value");
+
     # description
-    $key = 0x40000006;
+    $key = 0x30000006;
     $hash{pack("L",$key)} = "an example of string";
 
     untie(%hash);
@@ -232,14 +235,9 @@ ok($string eq "/path/to/list", "Resource->getPath()");
 $type = $resource->getType();
 ok($type == EDG::WP4::CCM::CacheManager::Resource->LIST, "Resource->getType()");
 
-# test getDerivation()
-$derivation = $resource->getDerivation();
-ok($derivation eq "lxplus.tpl,hardware.tpl,lxplust_025.tpl",
-   "Resource->getDerivation()");
-
 # test getChecksum()
 $checksum = $resource->getChecksum();
-ok($checksum eq md5_hex($derivation), "Resource->getChecksum()");
+ok($checksum eq md5_hex(chr(48).chr(0).chr(49)."|list"), "Resource->getChecksum()");
 
 # test getDescription()
 $description = $resource->getDescription();
@@ -355,4 +353,3 @@ ok($resource->getNextElement()->getValue() eq "element zero",
          "Resource->getNextElement() element zero");
 #ok($resource->currentElementName() eq "zero",
 #   "Resource->currentElementName()");
-

--- a/src/test/perl/xmlpan.t
+++ b/src/test/perl/xmlpan.t
@@ -40,8 +40,6 @@ sub InterpretNode
     foreach my $a (keys %$att) {
         if ($a eq 'name') {
             $val->{NAME} = $att->{$a};
-        } elsif ($a eq 'derivation') {
-            $val->{DERIVATION} = $att->{$a};
         } elsif ($a eq 'checksum') {
             $val->{CHECKSUM} = $att->{$a};
         } elsif ($a eq 'acl') {


### PR DESCRIPTION
Remove all references to this functionality as it is not supported.
    
This appears to have been a method for tracking where profile values were changed but was removed after the very first Quattor workshop for performance reasons and was never implemented in the current Java implementation version of panc.
    
This is backwards incompatible as it changes the on-disk DB format, but the field has always been null.
Add `ccm fetch -f` to the post-install script to ensure the profile is updated immediately.

Resolves #134.